### PR TITLE
Add vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ scbU
 npm-debug.log
 .DS_Store
 html_app/index.html
+
+
+.vagrant/
+static/

--- a/StarCellBio/views.py
+++ b/StarCellBio/views.py
@@ -267,7 +267,11 @@ def get_student_courses(request, **kwargs):
             #     if (
             #                 a.assignmentID == 'decusability' or a.assignmentID == 'scb_ex1' or a.assignmentID == 'microscopy_usability'):  # or a.assignmentID == 'microscopy_test' ): #or a.assignmentID == 'assignment_706_2014_ps2'):
             #         all.append(dictionary)
-            retval = {'is_student': True, 'list': all, 'is_auth': False, 'is_selected': all[0]['id'], 'token': token1}
+            is_selected = None
+            if len(all) > 0:
+                is_selected = all[0]['id']
+
+            retval = {'is_student': True, 'list': all, 'is_auth': False, 'is_selected': is_selected, 'token': token1}
     response = HttpResponse("var get_student_courses_result = {0};".format(json.dumps(retval)))
     response.set_cookie("scb_username", request.user.username)
     response['Content-Type'] = 'text/javascript'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,59 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "provision/ansible-dev.yml"
+  end
+  # config.vm.provision "shell", path: "provision.sh"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.33.200"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+end

--- a/html_app/watch.py
+++ b/html_app/watch.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
-from fsevents import Observer
-from fsevents import Stream
 import os
 import time
 from threading import Timer
 from subprocess import call
 
-#root = os.environ['PROJECT_HOME']+'/html_app/'
-root = os.environ['VIRTUAL_ENV']+'/starcellbio_html/html_app/'
+have_watcher = True
+try:
+    from fsevents import Observer
+    from fsevents import Stream
+except ImportError:
+    have_watcher = False
+
+
+root = os.environ['PROJECT_HOME'] + '/html_app/'
+# root = os.environ['VIRTUAL_ENV']+'/starcellbio_html/html_app/'
 
 
 global_update_index = True
@@ -109,10 +115,11 @@ for subdir, dir, files in os.walk( root ):
 
 update_index_html()
 
-try:
-    observer = Observer()
-    stream = Stream( callback , root , file_events=True)
-    observer.schedule(stream)
-    observer.run()
-except:
-    observer.stop()
+if have_watcher:
+    try:
+        observer = Observer()
+        stream = Stream( callback , root , file_events=True)
+        observer.schedule(stream)
+        observer.run()
+    except:
+        observer.stop()

--- a/provision/ansible-dev.yml
+++ b/provision/ansible-dev.yml
@@ -11,6 +11,7 @@
       - python-virtualenv
       - libncurses5-dev
       - python-mysqldb
+      - openjdk-6-jre
     pip_packages:
       - virtualenvwrapper
     venv_name: starcellbio
@@ -67,6 +68,12 @@
         executable=/bin/bash
         chdir=/vagrant
         {{ venv_path }}/bin/python manage.py collectstatic --noinput
+
+    - name: Compile files
+      shell: >
+        exceutable=/bin/bash
+        chdir=/vagrant/html_app
+        {{ venv_path }}/bin/python watch.py
 
     - name: Drop profile
       shell: >

--- a/provision/ansible-dev.yml
+++ b/provision/ansible-dev.yml
@@ -1,0 +1,75 @@
+---
+- hosts: all
+  vars:
+    apt_packages:
+      - libmysqlclient-dev
+      - mysql-client
+      - mysql-server
+      - python-pip
+      - build-essential
+      - python-dev
+      - python-virtualenv
+      - libncurses5-dev
+      - python-mysqldb
+    pip_packages:
+      - virtualenvwrapper
+    venv_name: starcellbio
+    venv_path: ~/.virtualenvs/{{ venv_name }}
+    db_name: starcellbio
+    db_user: starcellbio
+    db_pass: 136a411ed9e8592089444b7164ffaf84
+  tasks:
+    - name: Install debian packages
+      sudo: yes
+      apt: name={{ item }} update_cache=yes
+      with_items: apt_packages
+
+    - name: Install pip packages
+      sudo: yes
+      pip: name={{ item }}
+      with_items: pip_packages
+    
+    - name: Create venv
+      shell: >
+        executable=/bin/bash
+        creates={{ venv_path }}
+        . /usr/local/bin/virtualenvwrapper.sh &&
+        mkvirtualenv {{ venv_name }}
+
+    - name: Install requirements
+      pip: requirements='/vagrant/requirements.txt' virtualenv={{ venv_path }}
+
+    - name: Create database
+      sudo: yes
+      mysql_db: name={{ db_name }}
+
+    - name: Create user
+      sudo: yes
+      mysql_user: >
+        name={{ db_user }}
+        password={{ db_pass }}
+        priv={{ db_name }}.*:ALL
+
+    - name: Sync DB
+      shell: >
+        executable=/bin/bash
+        chdir=/vagrant
+        {{ venv_path }}/bin/python manage.py syncdb --noinput
+
+    - name: Load data
+      shell: >
+        executable=/bin/bash
+        chdir=/vagrant
+        {{ venv_path }}/bin/python manage.py loaddata backend statuses courses assignments studentassignments
+
+    - name: Collect Static
+      shell: >
+        executable=/bin/bash
+        chdir=/vagrant
+        {{ venv_path }}/bin/python manage.py collectstatic --noinput
+
+    - name: Drop profile
+      shell: >
+        creates=~/.ansible-profile
+        cat /vagrant/provision/vagrant_env >> ~/.profile;
+        touch ~/.ansible-profile

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+sudo apt-get update;
+sudo apt-get install libmysqlclient-dev mysql-client mysql-server python-pip build-essential python-dev python-virtualenv libncurses5-dev -y
+sudo service mysql start
+sudo pip install virtualenvwrapper
+source virtualenvwrapper.sh
+mkvirtualenv starcellbio
+cd /vagrant
+pip install -r requirements.txt
+
+echo "CREATE DATABASE starcellbio; GRANT ALL PRIVILEGES ON starcellbio.* TO 'starcellbio'@'localhost' IDENTIFIED BY '136a411ed9e8592089444b7164ffaf84';" | sudo mysql
+
+python manage.py syncdb
+python manage.py loaddata backend statuses courses assignments studentassignments
+

--- a/provision/vagrant_env
+++ b/provision/vagrant_env
@@ -1,0 +1,3 @@
+source virtualenvwrapper.sh
+workon starcellbio
+cd /vagrant

--- a/provision/vagrant_env
+++ b/provision/vagrant_env
@@ -1,3 +1,4 @@
 source virtualenvwrapper.sh
 workon starcellbio
 cd /vagrant
+export PROJECT_HOME=/vagrant

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django==1.4.2
+Django==1.4.18
 MacFSEvents==0.2.8
 Markdown==2.2.1
-MySQL-python==1.2.4
+MySQL-python==1.2.5
 PyYAML==3.10
 Pygments==1.5
 django-allauth==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Django==1.4.18
-MacFSEvents==0.2.8
 Markdown==2.2.1
 MySQL-python==1.2.5
 PyYAML==3.10

--- a/watcher_requirements.txt
+++ b/watcher_requirements.txt
@@ -1,0 +1,1 @@
+MacFSEvents==0.2.8


### PR DESCRIPTION
This is cherry-picked from another feature branch and upgrades django to the current security release of 1.4.  It also moves the Mac only python library to it's own requirements file so that it can be installed in Linux.  So new developers wanting to develop on Mac will need to also `pip install -r watcher_requirements.txt` if they want to run watcher.
