### PR TITLE
Port forward 8100 with vagrant.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   config.vm.network "private_network", ip: "192.168.33.200"
-  config.vm.network :forwarded_port, guest: 8000, host: 8000
+  config.vm.network :forwarded_port, guest: 8100, host: 8100
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
   # your network.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   config.vm.network "private_network", ip: "192.168.33.200"
-
+  config.vm.network :forwarded_port, guest: 8000, host: 8000
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
   # your network.


### PR DESCRIPTION
This is useful when private_networks don't work properly. (When using the Cisco VPN client, for instance)
