### PR TITLE
FACS: choose condition. Fixes #72

### DIFF
--- a/html_app/ui/facs.soy
+++ b/html_app/ui/facs.soy
@@ -356,25 +356,38 @@ FACS Main View
  -->
             
             <td class=' scb_s_facs_samples_table_td {if $r.display_sample}{else}scb_s_experiment_setup_table_border{/if}' style='width:232px;'>
-            	{if $r.lane and length(keys($kinds)) == 1}
-            	    <select class="scb_f_facs_select_conditions" role='select'
-			        facs_id='{$facs.id}' assignment_id="{$assignment.id}" experiment_id="{$experiment.id}"
-			        lane_kind="{$r.kind}" lane_id="{if $r.kind == 'existing'}{$r.lane.id}{/if}"
-	                {if $r.is_sample_enabled}{else}disabled="disabled"{/if}
-	                >
-	                {if $r.kind == 'existing'}
-			                {foreach $k in keys($kinds)}
-			                    {foreach $c in keys($kinds[$k].conditions)}
-			                    <option value='{$c}' role='option' {if $r.lane.conditions == $c}selected="selected"{/if}>
-                                    {$kinds[$k].conditions[$c].name}
-                                </option>
+            	{if $r.lane and length(keys($kinds)) >= 1}
+            	   {if $r.lane.kind != 'whole'}
+            	        {if length(keys($kinds[$r.lane.kind].conditions)) > 1}
+                            <select class="scb_f_facs_select_conditions" role='select'
+                            facs_id='{$facs.id}' assignment_id="{$assignment.id}" experiment_id="{$experiment.id}"
+                            lane_kind="{$r.kind}" lane_id="{if $r.kind == 'existing'}{$r.lane.id}{/if}"
+                            {if $r.is_sample_enabled}{else}disabled="disabled"{/if}
+                            >
+                            {if $r.kind == 'existing'}
+                                {foreach $k in keys($kinds)}
+                                    {foreach $c in keys($kinds[$k].conditions)}
+                                    <option value='{$c}' role='option' {if $r.lane.conditions == $c}selected="selected"{/if}>
+                                        {$kinds[$k].conditions[$c].name}
+                                    </option>
+                                    {/foreach}
+                                    {if length(keys($kinds[$k].conditions)) >= 1}
+                                       {if not $r.lane.conditions}
+                                       <option  role='option'selected="selected" disabled="disabled" value=''>Select Condition</option>
+                                       {/if}
+                                    {/if}
                                 {/foreach}
-                                 {if length(keys($kinds[$k].conditions)) >= 1}
-                                  {if not $r.lane.conditions}
-	                                <option  role='option'selected="selected" disabled="disabled" value=''>Select Condition</option>
-	                                {/if}
-	                            {/if}
-			                {/foreach}
+                            {/if}
+                        {else}
+                        {foreach $k in keys($kinds)}
+                            {foreach $c in keys($kinds[$k].conditions)}
+                            <input class="scb_f_facs_select_conditions" facs_id='{$facs.id}'
+                           assignment_id='{$assignment.id}' experiment_id='{$experiment.id}' type="radio" value="{$c}" cell_treatment_id='{$r.cell_treatment.id}'
+                           lane_kind="{$r.kind}" lane_id="{if $r.kind == 'existing'}{$r.lane.id}{/if}"
+                            {if $r.is_sample_enabled }checked="checked"{/if} /><span class="scb_s_western_blot_choose_gel_type_input_text ">{$assignment.template.facs_kinds[$k].conditions[$c].name}</span>
+                            {/foreach}
+                        {/foreach}
+                        {/if}
 	                {/if}
                 {/if}
             </td>


### PR DESCRIPTION
If "facs kind" is 'whole' then condition is blank.
For other "facs kinds":  
- if there is only one condition then a checked radio button for that condition is displayed,
- for more conditions a dropdown menu is displayed.
