### PR TITLE
Gate values for pseudo logarithmic scale

### DIFF
--- a/html_app/components/FACSModelFactory.js
+++ b/html_app/components/FACSModelFactory.js
@@ -331,8 +331,9 @@ scb.components.FACSModelFactory = function scb_components_FACSModelFactory(model
                 grid: {clickable: true, hoverable: true, borderWidth: 0, aboveData: true, autoHighlight: false,  markings: [ { xaxis: { from: 0, to: template.model.facs.max ? template.model.facs.max:  150 }, 
                 			yaxis: { from: 0, to: 0 }, color: "#000" },
                        { xaxis: { from: 0, to: 0 }, yaxis: { from: 0, to: 100 }, color: "#000" }]},
-            };            
-            var step= template.model.facs.ticks[1]-template.model.facs.ticks[0];
+            };
+            /* Old assignments do not have ticks */
+            var step= template.model.facs.ticks?(template.model.facs.ticks[1]-template.model.facs.ticks[0]) : 50;
             
             if (('' + shape).toLowerCase() == 'normal') {
                 var data = [];

--- a/html_app/ui/FacsView.js
+++ b/html_app/ui/FacsView.js
@@ -11,6 +11,7 @@ scb.ui.static.FacsView.MAX_GATE = 150;
 
 
 scb.ui.static.FacsView.parse = function (element) {
+
     var assignment_id = $(element).attr('assignment_id');
     var experiment_id = $(element).attr('experiment_id');
     var facs_id = $(element).attr('facs_id');
@@ -729,6 +730,10 @@ scb.ui.static.FacsView.evaluate_chart = function (state) {
         var xaxes = plot.getXAxes()[0];
         var yaxes = plot.getYAxes()[0];
         var sensitivity = 4;
+
+        /* Old assignments do not have max value given, they were using the value of a constant MAX_VALUE=150*/
+        var max_x = state.assignment.template.model.facs.max;
+        max_x = max_x ? max_x : 150;
         
         if(state.facs.samples_finished && state.facs_lane.selected_gate){
 				var selected_gate = state.facs.selected_lane.selected_gate;
@@ -799,8 +804,8 @@ scb.ui.static.FacsView.evaluate_chart = function (state) {
                 if (!isNaN(from)) {
                     var to = px;
                     to = to > 0 ? to : 0;
-                    to = to > scb.ui.static.FacsView.MAX_GATE  ? scb.ui.static.FacsView.MAX_GATE  : to;
-                    to = to < 0 ? 0 : to;
+                    to = to > max_x ? max_x  : to;
+                    to = to < 0 ? 0 : to; //not sure why this is needed?
                     if (point_to_edit) {
                     			_.each(state.facs_lane.canvas_metadata_analysis.points, function(x){
 									if(point_to_edit.from == x.to &&  Math.abs(point_to_edit.y- x.y) == 5 && Math.abs(from- x.to) < sensitivity){
@@ -956,9 +961,6 @@ scb.ui.static.FacsView.evaluate_chart = function (state) {
                 
                 		console.info("SET FROM " + px);
 						from = 0;
-						from = from > 0 ? from : 0;
-						from = from > scb.ui.static.FacsView.MAX_GATE  ? scb.ui.static.FacsView.MAX_GATE  : from;
-						from = from < 0 ? 0 : from;
 						fromy= py > 16 ? py: 16;
 						fromy = fromy > 90 ? 90: fromy;
 						from_point = {top: (e.clientY - $('.scb_s_facs_chart_wrapper', '.scb_s_facs_view').get(0).getBoundingClientRect().top),
@@ -969,8 +971,7 @@ scb.ui.static.FacsView.evaluate_chart = function (state) {
                 	if (!isNaN(from)) {
 						var to = px;
 						to = to > 0 ? to : 0;
-						to = to > scb.ui.static.FacsView.MAX_GATE  ? scb.ui.static.FacsView.MAX_GATE  : to;
-						to = to < 0 ? 0 : to;
+						to = to > max_x ? max_x  : to;
 						if (point_to_edit) {
 							if (Math.abs(point_to_edit.from - from) < sensitivity) {
 								point_to_edit.from = to;
@@ -1001,8 +1002,7 @@ scb.ui.static.FacsView.evaluate_chart = function (state) {
 						console.info("SET FROM " + px);
 						from = px;
 						from = from > 0 ? from : 0;
-						from = from > scb.ui.static.FacsView.MAX_GATE  ? scb.ui.static.FacsView.MAX_GATE  : from;
-						from = from < 0 ? 0 : from;
+						from = from > max_x  ? max_x : from;
 						fromy= (py > 16 ? py: 16);
 						fromy = (fromy > 90 ? 90: fromy)-5;
 						from_point = {top: (e.clientY - $('.scb_s_facs_chart_wrapper', '.scb_s_facs_view').get(0).getBoundingClientRect().top),
@@ -1011,10 +1011,9 @@ scb.ui.static.FacsView.evaluate_chart = function (state) {
 						var point = match(px, py-5);
 						point_to_edit = point;
 
-						var to = scb.ui.static.FacsView.MAX_GATE ;
+						var to = max_x ;
 						to = to > 0 ? to : 0;
-						to = to > scb.ui.static.FacsView.MAX_GATE  ? scb.ui.static.FacsView.MAX_GATE  : to;
-						to = to < 0 ? 0 : to;
+						to = to > max_x  ? max_x  : to;
 						if (point_to_edit) {
 							if (Math.abs(point_to_edit.from - from) < sensitivity) {
 								point_to_edit.from = to;
@@ -1076,8 +1075,7 @@ scb.ui.static.FacsView.evaluate_chart = function (state) {
 					console.info("SET FROM " + px);
 					from = px;
 					from = from > 0 ? from : 0;
-					from = from > scb.ui.static.FacsView.MAX_GATE  ? scb.ui.static.FacsView.MAX_GATE  : from;
-					from = from < 0 ? 0 : from;
+					from = from > max_x  ? max_x  : from;
 					fromy= py > 16 ? py: 16;
 					fromy = fromy > 90 ? 90: fromy;
 					from_point = {top: (e.clientY - $('.scb_s_facs_chart_wrapper', '.scb_s_facs_view').get(0).getBoundingClientRect().top),
@@ -1146,8 +1144,7 @@ scb.ui.static.FacsView.evaluate_chart = function (state) {
                     console.info("SET TO " + px);
                     var to = px;
                     to = to > 0 ? to : 0;
-                    to = to > scb.ui.static.FacsView.MAX_GATE  ? scb.ui.static.FacsView.MAX_GATE  : to;
-                    to = to < 0 ? 0 : to;
+                    to = to > max_x  ? max_x  : to;
                     state.facs_lane.canvas_metadata_analysis.points.push({from: Math.round(from), to: Math.round(to), y: Math.round(fromy)});
                     scb.ui.static.FacsView.reevaluate_metadata(state);
                     state.facs.apply_dna_analysis_to_all = false;

--- a/html_app/ui/facs.soy
+++ b/html_app/ui/facs.soy
@@ -767,7 +767,7 @@ Propidium Iodide (PI) (X-axis) of each cell within the sample. &nbsp;
             <td class="{if $range.bisector_id == 'b'}scb_s_facs_tools_analyze_bisector_border{/if}">
                 {$range.bisector_id}
             </td>
-            <td class="{if $range.bisector_id == 'b'}scb_s_facs_tools_analyze_bisector_border{/if}">{$range.from} - {$range.to}</td>
+            <td class="{if $range.bisector_id == 'b'}scb_s_facs_tools_analyze_bisector_border{/if}">{$range.display_from} - {$range.display_to}</td>
             <td class="{if $range.bisector_id == 'b'}scb_s_facs_tools_analyze_bisector_border{/if}">{$range.percentage}</td>
             <td class="{if $range.bisector_id == 'b'}scb_s_facs_tools_analyze_bisector_border{/if}">
                 <img class='scb_f_facs_analyze_remove_point scb_s_facs_analyze_remove_point' assignment_id='{$assignment.id}'


### PR DESCRIPTION
The maximum value at which a gate could be placed was bound to 150. Now it is limited by the maximum x value on the plot.
Added two new attributes to range (object that represents the gate):
- display_from
- display_to

For pseudo logarithmic scale both values are rescaled according to the actual 'from' and 'to' values:
![codecogseqn 1](https://cloud.githubusercontent.com/assets/7574259/6973988/e545b9a4-d95c-11e4-98ef-67c805bf2f7c.gif)

where step is the smallest distance between any 'tick' value,
x and x' is the original and scaled value of the x coordinate of the point.
