### PR TITLE
Add mail server to development system

### DIFF
--- a/provision/ansible-dev.yml
+++ b/provision/ansible-dev.yml
@@ -16,6 +16,7 @@
       - nodejs-legacy
       - git
       - emacs24-nox
+      - postfix
     pip_packages:
       - virtualenvwrapper
     venv_name: starcellbio


### PR DESCRIPTION
This adds a mail server to the vagrant system.  After this merges, you should be able run `vagrant provision`, and creating accounts should work without an error
