### PR TITLE
Switch to non-deprecated migrate command

### DIFF
--- a/provision/ansible-dev.yml
+++ b/provision/ansible-dev.yml
@@ -63,7 +63,7 @@
       shell: >
         executable=/bin/bash
         chdir=/vagrant
-        {{ venv_path }}/bin/python manage.py syncdb --noinput
+        {{ venv_path }}/bin/python manage.py migrate --noinput
 
     - name: Load data
       shell: >


### PR DESCRIPTION
Just a minor change to use migrate instead of syncdb now we are on 1.7
