### PR TITLE
Run migrations during vagrant provision

### DIFF
--- a/provision/ansible-dev.yml
+++ b/provision/ansible-dev.yml
@@ -65,6 +65,12 @@
         chdir=/vagrant
         {{ venv_path }}/bin/python manage.py syncdb --noinput
 
+    - name: Run migrations
+      shell: >
+        executable=/bin/bash
+        chdir=/vagrant
+        {{ venv_path }}/bin/python manage.py migrate --noinput
+
     - name: Load data
       shell: >
         executable=/bin/bash


### PR DESCRIPTION
It's worth noting that the migrations in `develop` aren't up-to-date, so this won't actually do anything until the migrations are corrected.
