### PR TITLE
light and laser for fluorescent microscopy

### DIFF
--- a/html_app/ui/MicroscopyView.js
+++ b/html_app/ui/MicroscopyView.js
@@ -83,8 +83,6 @@ scb.ui.static.MicroscopyView.parse = function (element) {
 
 
 scb.ui.static.MicroscopyView.scb_s_microscopy_lens_draw_slide = function(state){
-
-	
 	var model = new scb.components.ModelFactory(state.context.template);
 	model.microscopy.compute(state);
     /* state.slides contains the computed image hash */
@@ -99,226 +97,190 @@ scb.ui.static.MicroscopyView.scb_s_microscopy_lens_draw_slide = function(state){
 	if(state.microscopy_lane.current_slides.length == 0){
 		state.microscopy_lane.current_slides = state.slides;
 	}
-	if(state.slide_type == 'Dye'){
-		$('.scb_s_microscopy_if').prop('disabled', true);
-	$('.scb_s_microscopy_if').prop('checked', false);
-	}
-	else if(state.slide_type == 'IHC'){
-		$('.scb_s_microscopy_if').prop('disabled', true);
-	$('.scb_s_microscopy_if').prop('checked', false);
-	}
-	else if(state.slide_type == 'IF' || state.slide_type == 'FLUOR'){
-		if((state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.if_type ) || (!state.microscopy_lane.lens_map.action  && state.slides.length > 1 )){
-			if(state.microscopy_lane.current_slides.length != 1){
-				$('.scb_s_microscopy_if').prop('disabled', false);
-				if($('.scb_s_microscopy_if[checked="checked"]').length > 0){
-					var selected_filter = $('.scb_s_microscopy_if[checked="checked"]').prop('title').toLowerCase();
-						$('.scb_f_microscopy_'+selected_filter).prop('checked', 'checked');
-						state.microscopy.red_enabled = false;
-						state.microscopy.blue_enabled = false;
-						state.microscopy.green_enabled = false;
-						state.microscopy.merge_enabled = false;
-						if(selected_filter == 'all')
-							selected_filter = 'merge';
-						state.microscopy[selected_filter+'_enabled'] = true;
-						state.microscopy_lane.lens_map.if_type = selected_filter;
-						img_sample = $.grep(state.microscopy_lane.current_slides, function(e){ return e.if_type == selected_filter; })[0].hash;
-				}
-				else{
-					if((state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.if_type == 'red') ){
-							set_filters('red', state);
-					}
-					else if((state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.if_type == 'green')){
-							set_filters('green', state);
-					}
-					else if((state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.if_type == 'blue')){
-							set_filters('blue', state);
-					}
-					else if((state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.if_type == 'merge')){
-							set_filters('all', state);
-					}
-					else if (state.slides[0].if_type =='red'){
-							set_filters('red',state);
-							state.microscopy_lane.lens_map.if_type = 'red';
-					}
-					else if (state.slides[0].if_type =='green'){
-							set_filters('green',state);
-							state.microscopy_lane.lens_map.if_type = 'green';
-					}
-					else if (state.slides[0].if_type =='blue'){
-							set_filters('blue',state);
-							state.microscopy_lane.lens_map.if_type = 'blue';
-					}
-					else if (state.slides[0].if_type =='merge'){
-							set_filters('all',state);
-							state.microscopy_lane.lens_map.if_type = 'merge';
-					}
-					else{
-							set_filters('red',state);
-							state.microscopy_lane.lens_map.if_type = 'red';
-					}
-				}
-			}
-			else{
-				var color = state.microscopy_lane.current_slides[0].if_type;
-				if(color =='merge')
-					color = 'all';
-				set_filters(color, state);
-			}
-		}
-		else{
-		
-			//how to categorize a single IF slide and initialize the filter state
-			if(state.slides[0].if_type == 'red' ){
-				set_filters('red',state);
-				state.microscopy_lane.lens_map.if_type = 'red';
-				$('.scb_s_microscopy_red').prop('disabled', false);
-				}
-			else if(state.slides[0].if_type == 'green'){
-				set_filters('green',state);
-				state.microscopy_lane.lens_map.if_type = 'green';
-				$('.scb_s_microscopy_green').prop('disabled', false);
-				}
-			else if(state.slides[0].if_type == 'blue'){
-				set_filters('blue',state);
-				state.microscopy_lane.lens_map.if_type = 'blue';
-				$('.scb_s_microscopy_blue').prop('disabled', false);
-				}
-			else if(state.slides[0].if_type == 'merge'){
-				set_filters('all',state);
-				state.microscopy_lane.lens_map.if_type = 'merge';
-				$('.scb_s_microscopy_all').prop('disabled', false);
-			}
-		}
-	}
+    var fluorescence = (state.slide_type == 'IF' || state.slide_type == 'FLUOR' || state.slide_type == 'DyeFluor');
+
+    if (fluorescence) {
+        if ((state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.if_type ) || (!state.microscopy_lane.lens_map.action && state.slides.length > 1 )) {
+            if (state.microscopy_lane.current_slides.length != 1) {
+                $('.scb_s_microscopy_if').prop('disabled', false);
+                if ($('.scb_s_microscopy_if[checked="checked"]').length > 0) {
+                    var selected_filter = $('.scb_s_microscopy_if[checked="checked"]').prop('title').toLowerCase();
+                    $('.scb_f_microscopy_' + selected_filter).prop('checked', 'checked');
+                    state.microscopy.red_enabled = false;
+                    state.microscopy.blue_enabled = false;
+                    state.microscopy.green_enabled = false;
+                    state.microscopy.merge_enabled = false;
+                    if (selected_filter == 'all')
+                        selected_filter = 'merge';
+                    state.microscopy[selected_filter + '_enabled'] = true;
+                    state.microscopy_lane.lens_map.if_type = selected_filter;
+                    img_sample = $.grep(state.microscopy_lane.current_slides, function (e) {
+                        return e.if_type == selected_filter;
+                    })[0].hash;
+                }
+                else {
+                    if ((state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.if_type == 'red')) {
+                        set_filters('red', state);
+                    }
+                    else if ((state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.if_type == 'green')) {
+                        set_filters('green', state);
+                    }
+                    else if ((state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.if_type == 'blue')) {
+                        set_filters('blue', state);
+                    }
+                    else if ((state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.if_type == 'merge')) {
+                        set_filters('all', state);
+                    }
+                    else if (state.slides[0].if_type == 'red') {
+                        set_filters('red', state);
+                        state.microscopy_lane.lens_map.if_type = 'red';
+                    }
+                    else if (state.slides[0].if_type == 'green') {
+                        set_filters('green', state);
+                        state.microscopy_lane.lens_map.if_type = 'green';
+                    }
+                    else if (state.slides[0].if_type == 'blue') {
+                        set_filters('blue', state);
+                        state.microscopy_lane.lens_map.if_type = 'blue';
+                    }
+                    else if (state.slides[0].if_type == 'merge') {
+                        set_filters('all', state);
+                        state.microscopy_lane.lens_map.if_type = 'merge';
+                    }
+                    else {
+                        set_filters('red', state);
+                        state.microscopy_lane.lens_map.if_type = 'red';
+                    }
+                }
+            }
+            else {
+                var color = state.microscopy_lane.current_slides[0].if_type;
+                if (color == 'merge')
+                    color = 'all';
+                set_filters(color, state);
+            }
+        }
+        else {
+
+            //how to categorize a single IF slide and initialize the filter state
+            if (state.slides[0].if_type == 'red') {
+                set_filters('red', state);
+                state.microscopy_lane.lens_map.if_type = 'red';
+                $('.scb_s_microscopy_red').prop('disabled', false);
+            }
+            else if (state.slides[0].if_type == 'green') {
+                set_filters('green', state);
+                state.microscopy_lane.lens_map.if_type = 'green';
+                $('.scb_s_microscopy_green').prop('disabled', false);
+            }
+            else if (state.slides[0].if_type == 'blue') {
+                set_filters('blue', state);
+                state.microscopy_lane.lens_map.if_type = 'blue';
+                $('.scb_s_microscopy_blue').prop('disabled', false);
+            }
+            else if (state.slides[0].if_type == 'merge') {
+                set_filters('all', state);
+                state.microscopy_lane.lens_map.if_type = 'merge';
+                $('.scb_s_microscopy_all').prop('disabled', false);
+            }
+        }
+    } else {
+        $('.scb_s_microscopy_if').prop('disabled', true);
+        $('.scb_s_microscopy_if').prop('checked', false);
+    }
 		
 	if(state.microscopy.light_on){
-			$('#brightup').prop('disabled', false);
-			$('#brightdown').prop('disabled', false);
-	}
-	else{
-			$('#brightup').prop('disabled', true);
-			$('#brightdown').prop('disabled', true);
-	}
-	
-	if(state.slide_type != 'IF' && !state.microscopy.light_on && !state.microscopy.laser_on){
-		init_wb('/images/microscopy/black.jpg');
-		disableSlider = true;
-		if_light_on_and_laser_on = false;
-	}
-	
-	else if(state.slide_type != 'IF' && state.microscopy.light_on && !state.microscopy.laser_on){
-			if(state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.src){
-				$('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
-				init(state.microscopy_lane.lens_map, false, false, draw, state.microscopy_lane.lens_map.src, notebook_id );
-			}
-			else{
-				state.microscopy_lane.lens_map.mag = state.slides[0].mag;
-				$('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
-				init(state.microscopy_lane.lens_map, true, false, draw, state.assignment.template.slides[img_sample], notebook_id);
-			}
-			disableSlider = false;
-			if_light_on_and_laser_on = false;
-	}
-	
-	else if(state.slide_type != 'IF' && !state.microscopy.light_on && state.microscopy.laser_on){
-		init_wb('/images/microscopy/black.jpg');
-		disableSlider = true;
-		if_light_on_and_laser_on = false;
-	}
-	
-	else if(state.slide_type != 'IF' && state.microscopy.light_on && state.microscopy.laser_on){
-			if(state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.src){
-				$('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
-				init(state.microscopy_lane.lens_map, false, false, draw, state.microscopy_lane.lens_map.src, notebook_id );
-			}
-			else{
-				state.microscopy_lane.lens_map.mag = state.slides[0].mag;
-				$('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
-				init(state.microscopy_lane.lens_map, true, false,  draw, state.assignment.template.slides[img_sample], notebook_id);
-			}
-			disableSlider = false;
-			if_light_on_and_laser_on = false;
-	}
-	
-	else if(state.slide_type == 'IF' && !state.microscopy.light_on && !state.microscopy.laser_on){
-			init_wb('/images/microscopy/black.jpg');
-			disableSlider = true;
-			if_light_on_and_laser_on = true;
-			change_brightness_lines(state.microscopy_lane.lens_map.brightness, true);
-	}
-	
-	else if(state.slide_type == 'IF' && state.microscopy.light_on && !state.microscopy.laser_on){
-		$('.scb_f_microscopy_light').addClass('scb_s_microscopy_switch_disabled');
-		$('.scb_f_microscopy_light').prop('disabled', true);
-		$('#brightdown').prop('disabled', true);
-		$('#brightup').prop('disabled', true);
-		if(state.microscopy_lane.lens_map.brightness >1 )
-			init_wb_mod(state.microscopy_lane.lens_map, '/images/microscopy/white.jpg');
-		else
-			init_wb_mod(state.microscopy_lane.lens_map, '/images/microscopy/black.jpg');
-		disableSlider = false;
-		enableIFSlider = true;
-		min_brightness = scb.ui.static.MicroscopyView.WHITE_MIN_BRIGHTNESS;
-		max_brightness = scb.ui.static.MicroscopyView.WHITE_MAX_BRIGHTNESS;
-		if_light_on_and_laser_on = true;
-		change_brightness_lines(state.microscopy_lane.lens_map.brightness, false);
-	}
-	
-	else if(state.slide_type == 'IF' && !state.microscopy.light_on && state.microscopy.laser_on){
-			if(state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.src){
-				$('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
-				state.microscopy_lane.lens_map.cache_brightness = state.microscopy_lane.lens_map.brightness;
-				state.microscopy_lane.lens_map.brightness = scb.ui.static.MicroscopyView.WHITE_MIN_BRIGHTNESS;
-				init(state.microscopy_lane.lens_map, false, true, draw, state.microscopy_lane.current_slides.length != 1 ? state.assignment.template.slides[img_sample]: state.microscopy_lane.lens_map.src, notebook_id );
-			}
-			else{
-				state.microscopy_lane.lens_map.mag = state.slides[0].mag;
-				$('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
-				state.microscopy_lane.lens_map.cache_brightness = state.microscopy_lane.lens_map.brightness;
-				state.microscopy_lane.lens_map.brightness = scb.ui.static.MicroscopyView.WHITE_MIN_BRIGHTNESS;
-				init(state.microscopy_lane.lens_map, true, true, draw, state.assignment.template.slides[img_sample], notebook_id);
-			}
-		disableSlider = true;
-		min_brightness=scb.ui.static.MicroscopyView.WHITE_MIN_BRIGHTNESS;
-		max_brightness=scb.ui.static.MicroscopyView.WHITE_MAX_BRIGHTNESS;
-		if_light_on_and_laser_on = true;
-	}
-	
-	else if(state.slide_type == 'IF' && state.microscopy.light_on && state.microscopy.laser_on){
-		disableSlider = false;
-		enableIFSlider = true;
-		$('.scb_f_microscopy_light').addClass('scb_s_microscopy_switch_disabled');
-		$('.scb_f_microscopy_light').prop('disabled', true);
-		$('#brightdown').prop('disabled', true);
-		$('#brightup').prop('disabled', true);
-		
-// 		if(state.microscopy_lane.lens_map.cache_brightness)
-// 			state.microscopy_lane.lens_map.brightness = state.microscopy_lane.lens_map.cache_brightness;
-// 		if(state.microscopy_lane.lens_map.brightness <=1){
-//  					$('#brightdown').prop('disabled', true);
-// 				}
-		if(state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.src){
-				$('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
-				init(state.microscopy_lane.lens_map, false, true, draw, state.microscopy_lane.current_slides.length != 1 ? state.assignment.template.slides[img_sample]: state.microscopy_lane.lens_map.src, notebook_id );
-		}
-		else{
-			state.microscopy_lane.lens_map.mag = state.slides[0].mag;
-			$('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
-			init(state.microscopy_lane.lens_map, true, true, draw, state.assignment.template.slides[img_sample], notebook_id);
-		}
-		min_brightness=scb.ui.static.MicroscopyView.WHITE_MIN_BRIGHTNESS;
-		max_brightness=scb.ui.static.MicroscopyView.WHITE_MAX_BRIGHTNESS;
-		if_light_on_and_laser_on = true;
-		
-	}
-	if(!disableSlider  && !enableIFSlider){
-		min_brightness = scb.ui.static.MicroscopyView.NORMAL_MIN_BRIGHTNESS;
-		max_brightness = scb.ui.static.MicroscopyView.NORMAL_MAX_BRIGHTNESS;
-	}
-	disableBlur = state.microscopy.disable_blur;
-	disableBrightness = state.microscopy.disable_brightness;
-	if(state.microscopy.disable_blur){
+	    $('#brightup').prop('disabled', false);
+	    $('#brightdown').prop('disabled', false);
+	} else{
+	    $('#brightup').prop('disabled', true);
+	    $('#brightdown').prop('disabled', true);
+    }
+    if (!fluorescence) {
+        if (state.microscopy.light_on) {
+            if (state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.src) {
+                $('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
+                init(state.microscopy_lane.lens_map, false, false, draw, state.microscopy_lane.lens_map.src, notebook_id);
+            } else {
+                state.microscopy_lane.lens_map.mag = state.slides[0].mag;
+                $('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
+                init(state.microscopy_lane.lens_map, true, false, draw, state.assignment.template.slides[img_sample], notebook_id);
+            }
+            disableSlider = false;
+            if_light_on_and_laser_on = false;
+        } else {
+            init_wb('/images/microscopy/black.jpg');
+            disableSlider = true;
+            if_light_on_and_laser_on = false;
+        }
+    } else { /* Fluorescent */
+        if (!state.microscopy.light_on && !state.microscopy.laser_on) {
+            init_wb('/images/microscopy/black.jpg');
+            disableSlider = true;
+            if_light_on_and_laser_on = true;
+            change_brightness_lines(state.microscopy_lane.lens_map.brightness, true);
+        } else if (state.microscopy.light_on && !state.microscopy.laser_on) {
+            $('.scb_f_microscopy_light').addClass('scb_s_microscopy_switch_disabled');
+            $('.scb_f_microscopy_light').prop('disabled', true);
+            $('#brightdown').prop('disabled', true);
+            $('#brightup').prop('disabled', true);
+            if (state.microscopy_lane.lens_map.brightness > 1)
+                init_wb_mod(state.microscopy_lane.lens_map, '/images/microscopy/white.jpg');
+            else
+                init_wb_mod(state.microscopy_lane.lens_map, '/images/microscopy/black.jpg');
+            disableSlider = false;
+            enableIFSlider = true;
+            min_brightness = scb.ui.static.MicroscopyView.WHITE_MIN_BRIGHTNESS;
+            max_brightness = scb.ui.static.MicroscopyView.WHITE_MAX_BRIGHTNESS;
+            if_light_on_and_laser_on = true;
+            change_brightness_lines(state.microscopy_lane.lens_map.brightness, false);
+        } else if (!state.microscopy.light_on && state.microscopy.laser_on) {
+            if (state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.src) {
+                $('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
+                state.microscopy_lane.lens_map.cache_brightness = state.microscopy_lane.lens_map.brightness;
+                state.microscopy_lane.lens_map.brightness = scb.ui.static.MicroscopyView.WHITE_MIN_BRIGHTNESS;
+                init(state.microscopy_lane.lens_map, false, true, draw, state.microscopy_lane.current_slides.length != 1 ? state.assignment.template.slides[img_sample] : state.microscopy_lane.lens_map.src, notebook_id);
+            } else {
+                state.microscopy_lane.lens_map.mag = state.slides[0].mag;
+                $('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
+                state.microscopy_lane.lens_map.cache_brightness = state.microscopy_lane.lens_map.brightness;
+                state.microscopy_lane.lens_map.brightness = scb.ui.static.MicroscopyView.WHITE_MIN_BRIGHTNESS;
+                init(state.microscopy_lane.lens_map, true, true, draw, state.assignment.template.slides[img_sample], notebook_id);
+            }
+            disableSlider = true;
+            min_brightness = scb.ui.static.MicroscopyView.WHITE_MIN_BRIGHTNESS;
+            max_brightness = scb.ui.static.MicroscopyView.WHITE_MAX_BRIGHTNESS;
+            if_light_on_and_laser_on = true;
+        } else if (state.microscopy.light_on && state.microscopy.laser_on) {
+            disableSlider = false;
+            enableIFSlider = true;
+            $('.scb_f_microscopy_light').addClass('scb_s_microscopy_switch_disabled');
+            $('.scb_f_microscopy_light').prop('disabled', true);
+            $('#brightdown').prop('disabled', true);
+            $('#brightup').prop('disabled', true);
+
+            if (state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.src) {
+                $('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
+                init(state.microscopy_lane.lens_map, false, true, draw, state.microscopy_lane.current_slides.length != 1 ? state.assignment.template.slides[img_sample] : state.microscopy_lane.lens_map.src, notebook_id);
+            }
+            else {
+                state.microscopy_lane.lens_map.mag = state.slides[0].mag;
+                $('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);
+                init(state.microscopy_lane.lens_map, true, true, draw, state.assignment.template.slides[img_sample], notebook_id);
+            }
+            min_brightness = scb.ui.static.MicroscopyView.WHITE_MIN_BRIGHTNESS;
+            max_brightness = scb.ui.static.MicroscopyView.WHITE_MAX_BRIGHTNESS;
+            if_light_on_and_laser_on = true;
+
+        }
+    }
+    if (!disableSlider && !enableIFSlider) {
+        min_brightness = scb.ui.static.MicroscopyView.NORMAL_MIN_BRIGHTNESS;
+        max_brightness = scb.ui.static.MicroscopyView.NORMAL_MAX_BRIGHTNESS;
+    }
+    disableBlur = state.microscopy.disable_blur;
+    disableBrightness = state.microscopy.disable_brightness;
+    if (state.microscopy.disable_blur){
 			$('#fblurup').prop('disabled', true);
 			$('#fblurdown').prop('disabled', true);
 			$('#blurup').prop('disabled', true);
@@ -664,7 +626,8 @@ scb.ui.static.MicroscopyView.scb_f_microscopy_load_slides = function(element){
     parsed.microscopy.samples_finished = true;
     parsed.microscopy.enable_samples = true;
     parsed.microscopy.lane_selected = scb.utils.get(parsed.microscopy.lanes_list.list, [0, 'id']);
-    if(parsed.microscopy.lanes_list.list[0].kind =='IF'){
+    var lane_kind = parsed.microscopy.lanes_list.list[0].kind;
+    if(lane_kind=='IF' || lane_kind == 'FLUOR' ){
     	parsed.microscopy.laser_on = true;
     	parsed.microscopy.light_on =false;
     }
@@ -683,7 +646,7 @@ scb.ui.static.MicroscopyView.scb_s_microscopy_slide_tab = function(element){
 	if (parsed.redisplay) {
         alert("INVALID ELEMENT!");
     }
-    if(parsed.microscopy_lane.kind == 'IF'){
+    if(parsed.microscopy_lane.kind == 'IF' || parsed.microscopy_lane.kind == 'FLUOR'){
     	parsed.microscopy.laser_on = true; 
     }
     else{
@@ -700,19 +663,19 @@ scb.ui.static.MicroscopyView.scb_s_microscopy_choose_samples_order_list_select =
 		if (parsed.redisplay) {
 			alert("INVALID ELEMENT!");
 		}
-	   if (parsed.microscopy.samples_finished) {
-	   		    if(parsed.microscopy_lane.kind == 'IF'){
-	   		    	parsed.microscopy.laser_on = true; 
-				}
-				else{
-					parsed.microscopy.laser_on = false; 
-				}
-			$('li', $(element).parent()).removeClass('scb_s_microscopy_sample_selected');
-			$(element).addClass('scb_s_microscopy_sample_selected');
-			parsed.microscopy.lane_selected = parsed.microscopy_lane.id;
-			parsed.microscopy.scroll = $('.scb_s_microscopy_choose_samples_order_list').scrollTop();
-			scb.ui.static.MainFrame.refresh();
-	   }
+        if (parsed.microscopy.samples_finished) {
+            if (parsed.microscopy_lane.kind == 'IF' || parsed.microscopy_lane.kind == 'FLUOR') {
+                parsed.microscopy.laser_on = true;
+            }
+            else {
+                parsed.microscopy.laser_on = false;
+            }
+            $('li', $(element).parent()).removeClass('scb_s_microscopy_sample_selected');
+            $(element).addClass('scb_s_microscopy_sample_selected');
+            parsed.microscopy.lane_selected = parsed.microscopy_lane.id;
+            parsed.microscopy.scroll = $('.scb_s_microscopy_choose_samples_order_list').scrollTop();
+            scb.ui.static.MainFrame.refresh();
+        }
    }
 }
 
@@ -1657,7 +1620,7 @@ scb.ui.static.MicroscopyView.register = function (workarea) {
     scb.utils.off_on(workarea, 'change', '.scb_f_microscopy_laser', function (e) {
     	
         var parsed = scb.ui.static.MicroscopyView.parse(this);
-        	parsed = resetScrollValue(parsed);
+        parsed = resetScrollValue(parsed);
 
 		if($(this).attr('checked') =='checked'){
 		
@@ -1672,7 +1635,7 @@ scb.ui.static.MicroscopyView.register = function (workarea) {
     scb.utils.off_on(workarea, 'change', '.scb_f_microscopy_light', function (e) {
     	
         var parsed = scb.ui.static.MicroscopyView.parse(this);
-	parsed = resetScrollValue(parsed);
+        parsed = resetScrollValue(parsed);
 
 		if($(this).attr('checked') =='checked'){
 			parsed.microscopy.light_on = true;

--- a/html_app/ui/MicroscopyView.js
+++ b/html_app/ui/MicroscopyView.js
@@ -214,16 +214,19 @@ scb.ui.static.MicroscopyView.scb_s_microscopy_lens_draw_slide = function(state){
             if_light_on_and_laser_on = false;
         }
     } else { /* Fluorescent */
+        /* Disable the light_on button for Fluorescent images */
+        $('.scb_f_microscopy_light').addClass('scb_s_microscopy_switch_disabled');
+        $('.scb_f_microscopy_light').prop('disabled', true);
+        $('#brightdown').prop('disabled', true);
+        $('#brightup').prop('disabled', true);
+
         if (!state.microscopy.light_on && !state.microscopy.laser_on) {
             init_wb('/images/microscopy/black.jpg');
             disableSlider = true;
             if_light_on_and_laser_on = true;
             change_brightness_lines(state.microscopy_lane.lens_map.brightness, true);
         } else if (state.microscopy.light_on && !state.microscopy.laser_on) {
-            $('.scb_f_microscopy_light').addClass('scb_s_microscopy_switch_disabled');
-            $('.scb_f_microscopy_light').prop('disabled', true);
-            $('#brightdown').prop('disabled', true);
-            $('#brightup').prop('disabled', true);
+
             if (state.microscopy_lane.lens_map.brightness > 1)
                 init_wb_mod(state.microscopy_lane.lens_map, '/images/microscopy/white.jpg');
             else
@@ -254,10 +257,7 @@ scb.ui.static.MicroscopyView.scb_s_microscopy_lens_draw_slide = function(state){
         } else if (state.microscopy.light_on && state.microscopy.laser_on) {
             disableSlider = false;
             enableIFSlider = true;
-            $('.scb_f_microscopy_light').addClass('scb_s_microscopy_switch_disabled');
-            $('.scb_f_microscopy_light').prop('disabled', true);
-            $('#brightdown').prop('disabled', true);
-            $('#brightup').prop('disabled', true);
+
 
             if (state.microscopy_lane.lens_map && state.microscopy_lane.lens_map.src) {
                 $('.scb_s_microscopy_mag').text(state.microscopy_lane.lens_map.mag);

--- a/html_app/ui/microscopy.gss
+++ b/html_app/ui/microscopy.gss
@@ -1437,6 +1437,9 @@ outline: none !important;
 	background: url('../../../images/microscopy/On_BTN_Gray.png') no-repeat !important;
 	cursor: default;
 }
+.scb_s_micro_arrows:disabled{
+    cursor: default;
+}
 
 
 .scb_f_microscopy_light:checked , .scb_f_microscopy_laser:checked{

--- a/html_app/ui/microscopy.soy
+++ b/html_app/ui/microscopy.soy
@@ -590,9 +590,16 @@
    			 </div>
     
     <div class = 'scb_s_microscopy_lens_controls_section_2'>
-    <span class="scb_s_microscopy_lens_label" id='scb_s_light_label' >Light:</span> <input aria-labelledby='scb_s_light_label' type="checkbox" class="scb_f_microscopy_light {if $microscopy.samples_finished}{else}scb_s_microscopy_switch_disabled{/if}" microscopy_id='{$microscopy.id}'
-			   assignment_id='{$assignment.id}' experiment_id='{$experiment.id}' {if $microscopy_line_id}microscopy_lane_id='{$microscopy_line_id}'{/if} 
-			   {if $microscopy.light_on}checked='checked'{else}{/if}   aria-checked='{if $microscopy.light_on}true{else}false{/if}' {if $microscopy.samples_finished}{else}disabled{/if}>
+        <span class="scb_s_microscopy_lens_label" id='scb_s_light_label' >Light:</span>
+        <input aria-labelledby='scb_s_light_label' type="checkbox"
+            class="scb_f_microscopy_light
+            {if $microscopy.samples_finished}{else}scb_s_microscopy_switch_disabled{/if}"
+            microscopy_id='{$microscopy.id}'
+            assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'
+            {if $microscopy_line_id}microscopy_lane_id='{$microscopy_line_id}'{/if}
+            {if $microscopy.light_on}checked='checked'{else}{/if}
+            aria-checked='{if $microscopy.light_on}true{else}false{/if}'
+            {if $microscopy.samples_finished}{else}disabled{/if}>
     </div>
     <div class = 'scb_s_microscopy_lens_controls_section_3'>
     				<span class="scb_s_microscopy_brightness_label"></span>


### PR DESCRIPTION
Fixes #221

Light is disabled (laser is on by default) for 'antibody labeling IF' or 'fluorescence' analyses types.
Light is 'on' by default for all other samples (laser is off).
