### PR TITLE
Convert ADMINS list to tuples (to make it settable by YAML config)

### DIFF
--- a/StarCellBio/settings.py
+++ b/StarCellBio/settings.py
@@ -231,3 +231,9 @@ DATABASES = {
         'PORT': DB_PORT,
     }
 }
+
+
+# Ensure that ADMINS is a tuple of tuples. This is necessary because there are
+# no tuples in YAML. When ADMINS is defined in YAML, it's imported as a list of
+# lists.
+ADMINS = tuple(tuple(admin) for admin in ADMINS)


### PR DESCRIPTION
Ultimately, this allows us to properly template the admins email list when deploying qa/prod via ansible.

I've tested this on a local devstack with the following settings.yml:

``` yaml
ADMINS:
  -
    - mitx-devops
    - mitx-devops@mit.edu
```
