### PR TITLE
ab: update samples when variables change

### DIFF
--- a/instructor/migrations/0005_remove_field_order.py
+++ b/instructor/migrations/0005_remove_field_order.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instructor', '0004_drug_time_unit'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='treatment',
+            options={},
+        ),
+        migrations.RemoveField(
+            model_name='treatment',
+            name='order',
+        ),
+    ]

--- a/instructor/models.py
+++ b/instructor/models.py
@@ -100,14 +100,9 @@ class CollectionTime(models.Model):
 
 class Treatment(models.Model):
     assignment = models.ForeignKey(Assignment, related_name='treatment')
-    order = models.IntegerField(default=0)
     drug = models.ForeignKey(Drug)
     temperature = models.ForeignKey(Temperature, blank=True, null=True)
     collection_time = models.ForeignKey(CollectionTime, blank=True, null=True)
-
-
-    class Meta:
-        ordering = ['order', ]
 
 
 class StrainTreatment(models.Model):

--- a/instructor/templates/instructor/protocols.html
+++ b/instructor/templates/instructor/protocols.html
@@ -43,7 +43,7 @@
                 </div>
             {% endfor %}
             <div>
-                <input type="submit" name="add" class='scb_s_gray_button scb_ab_s_experiment_setup_add_button'
+                <input type="submit" name="add_drug" class='scb_s_gray_button scb_ab_s_experiment_setup_add_button'
                        value="ADD">
             </div>
             <div class="{% if not has_temperature %}scb_ab_s_hide_variable{% endif %}">
@@ -62,7 +62,7 @@
 
                 {% endfor %}
                 <div>
-                    <input type="submit" name="add" class='scb_s_gray_button scb_ab_s_experiment_setup_add_button'
+                    <input type="submit" name="add_temperature" class='scb_s_gray_button scb_ab_s_experiment_setup_add_button'
                            value="ADD">
                 </div>
             </div>
@@ -89,7 +89,7 @@
                     </div>
                 {% endfor %}
                 <div>
-                    <input type="submit" name="add" class='scb_s_gray_button scb_ab_s_experiment_setup_add_button'
+                    <input type="submit" name="add_collection" class='scb_s_gray_button scb_ab_s_experiment_setup_add_button'
                            value="ADD">
                 </div>
             </div>

--- a/instructor/templates/instructor/strain_protocols.html
+++ b/instructor/templates/instructor/strain_protocols.html
@@ -1,26 +1,34 @@
 {% extends "instructor/assignment_sidebar.html" %}
 
 {% block right_side %}
-
-    <div class='scb_s_assignment_setup_course_name_heading'>
-        4. Below are all possible combinations of strains and
-        treatment protocols.
+    <div class="scb_ab_s_heading_div">
+        <div class="scb_ab_s_page_title">Protocols</div>
+        <div class='scb_ab_s_heading_description'>
+            Below are all possible combinations of strains and
+            treatment protocols.
+        </div>
+        <ul>
+            <li class='scb_ab_s_heading_instructions'>
+                You can delete irrelevant combinations and
+                sort the combinations into the desired order.
+            </li>
+            <li class='scb_ab_s_heading_instructions'>
+                If you would like to edit individual experimental variables,
+                go back to the previous page.
+            </li>
+        </ul>
+        <br>
+        <div class='scb_ab_s_heading_description scb_ab_s_samples_heading'>Samples</div>
+        <button class="scb_s_gray_button scb_ab_s_show_protocols_btn toggle_protocols" data-show="false">
+            SHOW ONLY SELECTED
+        </button>
     </div>
-    <div class='scb_s_experiment_setup_subtitle'>
-        You can delete irrelevant combinations and
-        sort the combinations into the desired order.
-    </div>
-    <div class='scb_s_experiment_setup_subtitle'>
-        If you would like to edit individual experimental variables,
-        go back to the previous page.
-    </div>
-    <div class='scb_s_assignment_setup_course_name_heading'>Samples</div>
-    <br>
-    <div>
+    <div class="scb_ab_s_form_container">
         <form method="post">{% csrf_token %}
             {{ formset.management_form }}
 
             <div class="scb_ab_s_row">
+                <div class="scb_ab_s_enable_sample">Select</div>
             {% for header in headers %}
                 <div>{{ header }}</div>
             {% endfor %}
@@ -28,6 +36,7 @@
 
             {% for form in formset %}
                 <div class="scb_ab_s_row">
+                    <div class="scb_ab_s_enable_sample">{{ form.enabled }}</div>
                     <div>{{ form.instance.strain }}</div>
                     <div>{{ form.instance.treatment.drug.name }}</div>
                     {% if has_concentration %}
@@ -60,7 +69,6 @@
                         </div>
                     {% endif %}
                     {{ form.id }}
-                    <div class="delete_checkbox">{{ form.DELETE }}</div>
                 </div>
             {% endfor %}
             <input type="submit"

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -150,7 +150,8 @@ select:disabled {
     display: inline;
 }
 .scb_ab_s_form_container{
-    padding-left: 30px;
+    padding-left: 20px;
+    padding-top: 10px;
 }
 .scb_s_delete_strain {
     border: 0;
@@ -242,6 +243,36 @@ select:disabled {
     font-weight: bold;
     width: 100px;
     text-align: center;
+}
+.scb_ab_s_row>div.scb_ab_s_enable_sample{
+    width: 50px;
+}
+.scb_ab_s_heading_div{
+    margin: 15px 10px;
+    font-family: 'sourcesanspro-semibold';
+    color: #316f94;
+    font-weight: bold;
+
+}
+.scb_ab_s_page_title{
+    font-size: 16pt;
+    padding-bottom: 10px;
+
+}
+.scb_ab_s_heading_description{
+    font-size: 12pt;
+}
+.scb_ab_s_heading_instructions{
+    font-size: 10pt;
+}
+.scb_ab_s_show_protocols_btn{
+    float: right;
+    margin-right:40px;
+    width: 160px;
+}
+.scb_ab_s_samples_heading{
+    display: inline-block;
+    padding-left: 10px;
 }
 
 

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -88,12 +88,12 @@ $(function(){
     /**
     * Select variables
     */
-
+    var showed_warning = false;
     $('.scb_ab_f_select_variable>input').click(function(){
         /* Want to warn the instructor*/
         var $checkbox= $(this);
         /* Var created is initialized in select_variables template */
-        if (created) {
+        if (created && !showed_warning) {
             $('body').prepend("<div class='error_overlay' role='presentation'></div>");
             $.jqDialog.confirm("Previously generated data will be lost. Would you like to continue?",
                 function () {
@@ -107,12 +107,14 @@ $(function(){
             );
             $('.jqDialog_header').remove();
             $('#jqDialog_box').prepend("<h1 class='jqDialog_header' role='heading' >Warning</h1>");
+            showed_warning=true;
         }else{
             select_variables();
         }
     });
 
     if($('.scb_ab_f_select_variable').length){
+
         select_variables()
     }
 
@@ -144,6 +146,16 @@ $(function(){
         }
 
     }
+    $(".toggle_protocols").click(function(){
+        var show= $(".toggle_protocols").data("show");
+        if(show){
+            $(".scb_ab_s_row").show();
+            $(".toggle_protocols").data("show", false).html("SHOW ONLY SELECTED");
+        }else{
+            $("input:checkbox:not(:checked)").parent().parent().hide();
+            $(".toggle_protocols").data("show", true).html("SHOW ALL");
+        }
+    });
 
 
 });


### PR DESCRIPTION
When Strains or Treatments are created, update strain treatment protocols. Instead of deleting samples, the user can uncheck the 'enabled' checkbox.
Edit: 
When reselecting experimental variables:
1) Show warning only once
2) delete all samples, and create new samples. 
Order samples by Strain, Treatment name, Temperature, Collection time.
Added a button to hide unselected samples.
