### PR TITLE
AB FACS: add axis preview in Histogram step of FlowCytometry

### DIFF
--- a/instructor/templates/instructor/facs_setup.html
+++ b/instructor/templates/instructor/facs_setup.html
@@ -35,6 +35,10 @@
             <div>{{ form.xrange }}</div>
             <div>{{ form.tick_values }}</div>
         </div>
+      <div style="display: block">
+         <canvas id="previewXAxis" class=" scb_ab_s_draw_histogram_canvas scb_ab_s_canvas_axis_preview"></canvas>
+      </div>
+
 
         <input type="submit"
                name="continue"
@@ -48,4 +52,7 @@
     <a href="{% url "facs_sample_prep" %}">
         <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
     </a>
+    <script type="text/javascript">
+    paper.install(window);
+    </script>
 {% endblock %}

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -672,3 +672,7 @@ input[type="checkbox"].disabled {
     background-image: url('../../../images/header/scb_close_button.png');
     background-repeat: no-repeat;
 }
+/* FACS setup histogram parameters */
+.scb_ab_s_canvas_axis_preview{
+    margin-left: 15px;
+}

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -428,6 +428,15 @@ $(function() {
     $(this).addClass("scb_ab_s_histogram_selected");
   });
 
+  /* Facs Histogram setup view */
+  if ($("#previewXAxis").length){
+
+    var x_range = $("#id_xrange").val();
+    var ticks = $("#id_tick_values").val();
+    paper.setup('previewXAxis');
+    draw_graph_background(x_range, ticks);
+    paper.view.update();
+  }
 
   /* Facs analyze view */
   if (typeof(histograms) !== 'undefined') {

--- a/instructor/ui/sketch_tool.js
+++ b/instructor/ui/sketch_tool.js
@@ -2,6 +2,7 @@
  * Sketching tool
  */
 
+AXIS_MARK_WIDTH = 3;
 
 function draw_graph_background(x_upper_bound, tick_values){
     var x, y, x_axis_ticks;
@@ -31,12 +32,14 @@ function draw_graph_background(x_upper_bound, tick_values){
     var x_coor, y_coor;
     _.each(x_axis_ticks, function(value){
         x_coor = X_AXIS_LENGTH_PX * value / x_upper_bound + X_ORIGIN;
-        y_coor = Y_ORIGIN + 13;
+        y_coor = Y_ORIGIN + 10;
+        draw_line(x_coor,Y_ORIGIN+AXIS_MARK_WIDTH, x_coor, Y_ORIGIN-AXIS_MARK_WIDTH);
         printText(x_coor, y_coor, value);
     });
     _.each(Y_AXIS_TICKS, function(value){
-        x_coor = X_ORIGIN - 10;
-        y_coor = Y_ORIGIN - (Y_AXIS_LENGTH_PX * value / Y_AXIS_LENGTH_VALUE) + 5;
+        x_coor = X_ORIGIN - 15;
+        y_coor = Y_ORIGIN - (Y_AXIS_LENGTH_PX * value / Y_AXIS_LENGTH_VALUE);
+        draw_line(X_ORIGIN + AXIS_MARK_WIDTH, y_coor, X_ORIGIN - AXIS_MARK_WIDTH, y_coor);
         printText(x_coor, y_coor, value);
     });
     nameYAxis();
@@ -142,8 +145,12 @@ function nameYAxis(){
 function printText(x, y, value){
     var text_obj = new paper.PointText(new paper.Point(x, y));
     text_obj.content = value;
-    // need to subtract half of the width from x
-    text_obj.position.x -= text_obj.bounds.width / 2;
+    // adjusting for the height of the text
+    text_obj.position.y += 5;
+    text_obj.style = {
+        fontSize: 12,
+        justification: 'center'
+    };
     return text_obj;
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?

Fix #626 
#### What's this PR do?

Allows the user to see what the canvas looks like with the saved parameters in Histogram page of FlowCytometry setup.
Added marks to axes.
![screen shot 2016-06-27 at 4 18 35 pm](https://cloud.githubusercontent.com/assets/7574259/16394372/dcb06d2c-3c82-11e6-9d05-1b64b77eba5a.png)
