### PR TITLE
Remove Live from exercise 2

### DIFF
--- a/html_app/assignments/scb_ex/assignment.js
+++ b/html_app/assignments/scb_ex/assignment.js
@@ -2170,49 +2170,20 @@ var __scb_sample_2 = {
       }
     },
     facs_kinds: {
-      'Live': {
-        'Anti': {
-          name: 'Antibody-labeling ',
-          conditions: {
-            'His_488': {
-              name: 'His 488'
-            },
-            'FLAG_488': {
-              name: 'FLAG 488'
-            },
-            'proX_488': {
-              name: 'ProX 488'
-            },
-            'proY_488': {
-              name: 'ProY 488'
-            }
-          }
-        },
-        'Dye': {
-          name: 'Dye/Stain',
-          conditions: {
-            'EGFR': {
-              name: 'EGFR'
-            }
-          }
-        }
-      },
-      'Fixed': {
-        'Anti': {
-          name: 'Antibody-labeling ',
-          conditions: {
-            'His_488': {
-              name: 'His 488'
-            },
-            'FLAG_488': {
-              name: 'FLAG 488'
-            },
-            'proX_488': {
-              name: 'ProX 488'
-            },
-            'proY_488': {
-              name: 'ProY 488'
-            }
+      'Anti': {
+        name: 'Antibody-labeling ',
+        conditions: {
+          'His_488': {
+            name: 'His 488'
+          },
+          'FLAG_488': {
+            name: 'FLAG 488'
+          },
+          'proX_488': {
+            name: 'ProX 488'
+          },
+          'proY_488': {
+            name: 'ProY 488'
           }
         }
       }
@@ -2659,12 +2630,10 @@ var __scb_sample_2 = {
         }
       },
       facs: {
-        is_ab: true,
-        ab_parser: {
-          'ticks': [50, 100, 150],
-          'max': 200,
-          'scale': 'pseudo',
-          'dna': {
+        'ticks': [50, 100, 150],
+        'max': 200,
+        'scale': 'pseudo',
+        'dna': {
           'parser_simple': [
             {
               match: [],
@@ -2820,8 +2789,6 @@ var __scb_sample_2 = {
             }
 
           ]
-
-        }
         }
       }
     }


### PR DESCRIPTION
#### What are the relevant tickets?

None
#### What's this PR do?

Remove the Live treatment in `facs_kinds`, which was added to test the functionality. Now can use this functionality through defining Live and Fixed treatments in FACS in the Assignment Builder. 

To test this: perform the experiment (NSF Exercise 2), notice only `fixed` is available for cell treatment. In analyze step each sample should produce a graph.
