### PR TITLE
ab facs: histogram edit button

### DIFF
--- a/instructor/templates/instructor/facs_analyze.html
+++ b/instructor/templates/instructor/facs_analyze.html
@@ -137,7 +137,9 @@
                         </div>
                         <div class="scb_ab_s_edit_icon_container">
                             <div class="scb_ab_col_edit">
-                                <div class="scb_ab_s_histogram_edit_grey_img">
+                                <div class="scb_ab_s_histogram_edit_grey_img scb_ab_f_edit_histogram"
+                                    data-row_id="row-{{ cell_treatment }}_{{ instance.id }}"
+                                    data-sample_treatment="{{ cell_treatment }}, {{ analysis }}, {{ condition }}">
                                 </div>
                             </div>
                         </div>

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -530,8 +530,8 @@ $(function() {
 
   }
 
-  /* Open Histogram Tools window */
-  $(".add_histogram_btn").click(function () {
+  /* ADD HISTOGRAM button: Open Histogram Tools window */
+  $(".add_histogram_btn, .scb_ab_f_edit_histogram").click(function () {
     /* this btn has the id of the corresponding row */
     var row_id = $(this).data('row_id');
     /* Get name of the sample from the row itself */
@@ -548,9 +548,12 @@ $(function() {
     /* Label x axis with condition name */
     mypapers[2].activate();
     nameXAxis(sample_treatment_array[2]);
+    if ($(this).hasClass("scb_ab_f_edit_histogram")){
+      $(".scb_ab_s_draw_histogram_view").hide();
+      $(".scb_ab_s_select_histogram_view").show();
+      paper.view.update();
+    }
   });
-
-
 });
 
 


### PR DESCRIPTION
#### What are the relevant tickets?

Fix #660 
#### What's this PR do?

Add functionality to the edit button on FACS Analyze page. The button opens the dialog view with the histogram library. 
