### PR TITLE
AB FACS: Enabled edit histogram button turns white

### DIFF
--- a/instructor/templates/instructor/facs_analyze.html
+++ b/instructor/templates/instructor/facs_analyze.html
@@ -203,7 +203,7 @@
                         </div>
                         <div class="scb_ab_s_edit_icon_container">
                             <div class="scb_ab_col_edit">
-                                <div class="scb_ab_s_histogram_edit_grey_img scb_ab_f_edit_histogram"
+                                <div class="scb_ab_s_histogram_edit_icon scb_ab_f_edit_histogram"
                                     data-row_id="row-{{ cell_treatment }}_{{ instance.id }}"
                                     data-sample_treatment="{{ cell_treatment }}, {{ analysis }}, {{ condition }}">
                                 </div>

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -513,17 +513,17 @@ input[type="checkbox"].disabled {
     margin-bottom: -15px;
     font-family: 'sourcesanspro-semibold';
 }
-.scb_ab_s_histogram_edit_grey_img {
-    background: url('../images/Draw_Histogram_Gray.png') no-repeat;
+.scb_ab_s_histogram_edit_icon{
     height: 28px;
-    background-size: 25px;
     margin: 10px 7px;
 }
-.scb_ab_s_histogram_edit_white_img{
-    background: url('../images/Draw_Histogram_White.png') no-repeat;
-    height: 28px;
+.scb_ab_s_edit_grey_img {
+    background: url('../images/Draw_Histogram_Gray.png') no-repeat;
     background-size: 25px;
-    margin: 10px 7px;
+}
+.scb_ab_s_edit_white_img {
+    background: url('../images/Draw_Histogram_White.png') no-repeat;
+    background-size: 25px;
 }
 
 /* Dialog view for analyze page */

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -461,6 +461,7 @@ $(function() {
       } else {
         data = histograms[instance_id]['fixed'];
       }
+      var $edit_icon = $("div.scb_ab_s_histogram_edit_icon[data-row_id='row-" + row_id + "']");
       if (data) {
         data = JSON.parse(data);
         canvas_data = convertToCanvas(data);
@@ -472,10 +473,12 @@ $(function() {
         });
         paper.view.update();
         $("button[data-row_id='row-" + row_id + "']").hide();
+        $edit_icon.addClass('scb_ab_s_edit_white_img');
       } else {
         $(canvas).css('display', 'none');
         $(canvas).siblings('div').css('display', 'none');
         $(canvas).parent().siblings('.scb_ab_s_copy_button_container').css('display', 'none');
+        $edit_icon.addClass('scb_ab_s_edit_grey_img');
       }
     });
 
@@ -557,7 +560,7 @@ $(function() {
   }
 
   /* ADD HISTOGRAM button: Open Histogram Tools window */
-  $(".add_histogram_btn, .scb_ab_f_edit_histogram").click(function () {
+  $(".add_histogram_btn, .scb_ab_f_edit_histogram.scb_ab_s_edit_white_img").click(function () {
     /* this btn has the id of the corresponding row */
     var row_id = $(this).data('row_id');
     /* Get name of the sample from the row itself */


### PR DESCRIPTION
#### What are the relevant tickets?

Depends on #659
Related to #667
#### What's this PR do?

Turn edit icons into white, when a histogram exists for the sample, and disable all the grey icons for which no histogram was selected yet.
