### PR TITLE
ab facs: back button fix

### DIFF
--- a/instructor/templates/instructor/facs_analyze.html
+++ b/instructor/templates/instructor/facs_analyze.html
@@ -229,7 +229,7 @@
                    value="SAVE"/>
         </form>
     </div>
-    <a href="{% url "facs_sample_prep" %}">
+    <a href="{% url "facs_setup" %}">
         <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
     </a>
     <script type="text/javascript">


### PR DESCRIPTION
#### What are the relevant tickets?

Fix #681 

The destination of the back button in 'analyze' page is changed from 'sample prep' to 'histogram'.
