### PR TITLE
ab: save and continue button

### DIFF
--- a/instructor/common.py
+++ b/instructor/common.py
@@ -1167,7 +1167,7 @@ def western_blot_band_intensity(request):
     # Page to go to on 'continue'
     next_view = 'common_assignments'
     if assignment.has_micro:
-        next_view = 'micro_sample_prep'
+        next_view = 'microscopy_sample_prep'
     elif assignment.has_fc:
         next_view = 'facs_sample_prep'
     wb, created = models.WesternBlot.objects.get_or_create(
@@ -1221,6 +1221,11 @@ def western_blot_band_intensity(request):
         'has_temperature': assignment.has_temperature,
         'has_collection_time': assignment.has_collection_time
     }
+    # need to decide to finish the assignment or
+    # to move on to next technique
+    save_and_continue_button = 'SAVE AND FINISH'
+    if assignment.has_fc:
+        save_and_continue_button = 'SAVE AND CONTINUE'
     return render_to_response(
         'instructor/wb_band_intensity.html',
         {
@@ -1228,6 +1233,7 @@ def western_blot_band_intensity(request):
             'access': json.dumps(assignment.access),
             'formset_group': formset_group,
             'variables': variables,
+            'save_and_continue': save_and_continue_button,
             'assignment_name': assignment.name,
             'section_name': 'Western Blotting',
             'page_name': 'wb_band_intensity',
@@ -1339,6 +1345,8 @@ def microscopy_analyze(request):
     mapping_pk = ""
     dialog_open = False
     if request.method == "POST" and 'continue' in request.POST:
+        if assignment.has_fc:
+            return redirect('facs_sample_prep')
         return redirect('common_assignments')
     if request.method == "POST" and 'upload' in request.POST:
         if len(request.FILES) > 0:
@@ -1397,6 +1405,10 @@ def microscopy_analyze(request):
         'has_temperature': assignment.has_temperature,
         'has_collection_time': assignment.has_collection_time
     }
+    # need to decide to finish the assignment or to move on to FACS
+    save_and_continue_button = 'SAVE AND FINISH'
+    if assignment.has_fc:
+        save_and_continue_button = 'SAVE AND CONTINUE'
     return render_to_response(
         'instructor/micro_analyze.html',
         {
@@ -1409,6 +1421,7 @@ def microscopy_analyze(request):
             'mapping_pk': mapping_pk,
             'image_groups': grouped_images,
             'variables': variables,
+            'save_and_continue': save_and_continue_button,
             'assignment_name': assignment.name,
             'section_name': 'Microscopy',
             'page_name': 'micro_analyze',

--- a/instructor/templates/instructor/micro_analyze.html
+++ b/instructor/templates/instructor/micro_analyze.html
@@ -128,7 +128,7 @@
       <input type="submit"
              name="continue"
              class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-             value="SAVE AND FINISH &nbsp; &#9654;">
+             value="{{ save_and_continue }} &nbsp; &#9654;">
       <input type="submit"
              name="save"
              class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"

--- a/instructor/templates/instructor/wb_band_intensity.html
+++ b/instructor/templates/instructor/wb_band_intensity.html
@@ -69,7 +69,7 @@
             <input type="submit"
                    name="continue"
                    class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE AND FINISH &nbsp; &#9654;">
+                   value="{{ save_and_continue }} &nbsp; &#9654;">
             <input type="submit"
                    name="save"
                    class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"


### PR DESCRIPTION
#### What are the relevant tickets?

Related to #674 
#### What's this PR do?

When on the last page of Western Blot, the button should be 'save and continue' if there are more techniques enabled in the 'Select Technique' page ( and should lead to next enabled technique).
When on the last page of Microscopy, the button should be 'save and continue' and lead to 'Sample Prep' page of facs if facs is enabled in this assignment.
