### PR TITLE
ab: strains fixes

### DIFF
--- a/instructor/common.py
+++ b/instructor/common.py
@@ -556,14 +556,9 @@ def assignments_edit_strains(request):
     pk = request.session['assignment_id']
     assignment = get_object_or_404(models.Assignment, id=pk)
     extra_fields = 0
-    if 'add' in request.POST or not models.Strains.objects.filter(
-        assignment=assignment
-    ):
-        extra_fields = 1
 
     StrainsFormSet = modelformset_factory(
         models.Strains,
-        extra=extra_fields,
         fields=['name'],
         can_delete=True
     )
@@ -590,7 +585,18 @@ def assignments_edit_strains(request):
 
     elif request.method == "POST" and 'continue' in request.POST:
         return redirect("common_assignments_variables")
+    # Add extra form if clicked ADD or none exist
+    if 'add' in request.POST or not models.Strains.objects.filter(
+        assignment=assignment
+    ).exists():
+        extra_fields = 1
 
+    StrainsFormSet = modelformset_factory(
+        models.Strains,
+        extra=extra_fields,
+        fields=['name'],
+        can_delete=True
+    )
     formset = StrainsFormSet(
         queryset=models.Strains.objects.filter(assignment=assignment)
     )

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -67,9 +67,17 @@ $(function() {
    */
   $("form input[type = 'text'], form input[type = 'number']").addClass("scb_ab_s_input_text_field");
   $("form select").addClass("scb_ab_s_form_select_field");
+
   /**
    * Edit Strains
    */
+  if($("input[name='continue']").attr('disabled') === 'disabled'){
+     $("#id_form-0-name").keyup(function(e){
+       if($(this).val() != '') {
+         $("input:disabled").attr('disabled', false).removeClass('disabled');
+       }
+     });
+  }
 
   $('.delete_checkbox input').each(function() {
     $(this).hide().after('<div class="checkbox_delete_image"/>');


### PR DESCRIPTION
#### What are the relevant tickets?

Fix #701 
#### What's this PR do?

Enable 'save and continue button when the user starts typing into the text field. 
Fixes the bug where an extra form appears, when user entered first strain and clicked 'Save'.
