### PR TITLE
Compile SOY files before gss files

### DIFF
--- a/html_app/build.py
+++ b/html_app/build.py
@@ -188,9 +188,13 @@ def processor(path):
 
 def process_all():
     for subdir, _, files in os.walk(ROOT):
-        for f in files:
-            path = "{}/{}".format(subdir, f)
-            processor(path)
+        soy_files = [f for f in files if f.endswith(".soy")]
+        gss_files = [f for f in files if f.endswith(".gss")]
+        other_files = [f for f in files if f not in soy_files and f not in gss_files]
+        for group in [soy_files, gss_files, other_files]:
+            for f in group:
+                path = "{}/{}".format(subdir, f)
+                processor(path)
 
     update_index_html()
 


### PR DESCRIPTION
#### What's this PR do?

`os.walk()` uses `os.listdir()` to get a list of filenames from a directory. In a file system files are not in alphabetical order, the order they are in is arbitrary. When a user runs `ls`, that command sorts the results before showing them to the user. For performance reasons, `os.listdir()` does not sort the filenames when it returns the list. Something in the new Travis image made the order change. If you look at the Travis logs there are many compilation errors with `build.py` from files which are missing. We didn't see those errors locally because if you run `build.py` at least two times, this problem goes away since the `soy` files which the `gss` files relied on were generated in the previous run.

This orders the compilation so that all soy files in a directory are compiled first, then the gss files, then all others.
