### PR TITLE
ab micro: remove image set

### DIFF
--- a/StarCellBio/urls.py
+++ b/StarCellBio/urls.py
@@ -292,6 +292,11 @@ urlpatterns += patterns(
         instructor_common.add_image_group,
         name="add_image_group"
     ),
+    url(
+        r'^ab/assignments/remove_image_set/$',
+        instructor_common.remove_image_group,
+        name="remove_image_group"
+    ),
     # Flow Cytometry
     url(
         r'^ab/assignments/submit_histogram/$',

--- a/instructor/common.py
+++ b/instructor/common.py
@@ -1840,6 +1840,20 @@ def remove_image(request):
 @assignment_selected
 @check_assignment_owner
 @login_required
+def remove_image_group(request):
+    pk = request.session['assignment_id']
+    group_id = request.POST.get('group_id')
+
+    models.MicroscopyGroupedImages.objects.filter(
+        id=group_id,
+        image_mapping__sample_prep__assignment__pk=pk
+    ).delete()
+    return HttpResponse()
+
+
+@assignment_selected
+@check_assignment_owner
+@login_required
 def copy_histogram(request):
     """
     Copy a histogram from one mapping to a given list mappings

--- a/instructor/templates/instructor/micro_analyze.html
+++ b/instructor/templates/instructor/micro_analyze.html
@@ -135,6 +135,9 @@
                       {% endwith %}
                     </div>
                   {% endfor %}
+                  <div class="scb_ab_s_filtered_image_grid">
+                    <div class="scb_s_ab_trash_icon remove_image_set" data-group_id="{{ image_set.id }}"></div>
+                  </div>
                 </div>
               {% endfor %}
             {% endif %}

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -222,13 +222,14 @@ select:disabled {
     width: 108px;
 }
 /* Delete trash icon*/
-.checkbox_delete_image{
+.scb_s_ab_trash_icon{
     background: url('images/setup/scb_remove.png') no-repeat;
     display:inline-block;
     height:20px;
     width: 15px;
     background-position: center;
     margin-left: 8px;
+    cursor: pointer;
 }
 .checkbox_image:hover {
     cursor: pointer;
@@ -245,9 +246,6 @@ select:disabled {
 
 .scb_ab_s_hide_variable{
     display:none;
-}
-.checkbox_delete_image{
-    cursor: pointer;
 }
 
 .scb_ab_s_row{

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -80,11 +80,11 @@ $(function() {
   }
 
   $('.delete_checkbox input').each(function() {
-    $(this).hide().after('<div class="checkbox_delete_image"/>');
+    $(this).hide().after('<div class="checkbox_form_delete scb_s_ab_trash_icon"/>');
 
   });
   if (typeof (access) !== 'undefined' && access === 'private') {
-    $('.checkbox_delete_image').on('click', function() {
+    $('.checkbox_form_delete').on('click', function() {
       /* Check the hidden checkbox */
       $(this).prev().prop('checked', true);
       /* Want to disable the input box for the strain */
@@ -365,7 +365,7 @@ $(function() {
       .attr('disabled', true);
     $('input[type="checkbox"],input[type="radio"]').addClass('disabled');
     $('input[value="ADD"]').attr('disabled', true).addClass('disabled');
-    $('.checkbox_delete_image').addClass('disabled');
+    $('.scb_s_ab_trash_icon').addClass('disabled');
   }
 
   function show_alert(error) {
@@ -715,6 +715,17 @@ $(function() {
         group_id: $(this).data('group_id'),
         filter: $(this).data('filter'),
         image_id: $(this).data('image_id')
+      }
+    }).then(function () {
+      window.location = '/ab/assignments/microscopy_analyze/';
+    });
+  });
+  $(".remove_image_set").click(function(){
+    $.ajax({
+      url: '/ab/assignments/remove_image_set/',
+      type: "POST",
+      data: {
+        group_id: $(this).data('group_id')
       }
     }).then(function () {
       window.location = '/ab/assignments/microscopy_analyze/';


### PR DESCRIPTION
#### What are the relevant tickets?

Fix #715 
#### What's this PR do?

Allows the instructor to remove image sets on Microscopy 'analyze' page.
