### PR TITLE
Rewriting microscopy filter controls

### DIFF
--- a/html_app/ui/microscopy.gss
+++ b/html_app/ui/microscopy.gss
@@ -550,7 +550,7 @@ input[type=radio].scb_s_microscopy_if:checked:before{
 	opacity: 1 !important;
 }
 
-.scb_f_microscopy_all{
+.scb_f_microscopy_merge{
 	height: 30px !important;
 	width: 30px !important;
 	right: 6px !important;
@@ -580,7 +580,7 @@ input[type=radio].scb_s_microscopy_if:checked:before{
 }
 
 
-.scb_f_microscopy_all:disabled{
+.scb_f_microscopy_merge:disabled{
 	background-image: url(../../../images/microscopy/Unavailable/Filter_All_Unavailable.png) !important;
 	background-repeat: no-repeat !important;
 }
@@ -601,7 +601,7 @@ input[type=radio].scb_s_microscopy_if:checked:before{
 }
 
 
-.scb_f_microscopy_all:checked{
+.scb_f_microscopy_merge:checked{
 	background-image: url(../../../images/microscopy/Selected/Filter_All_Selected.png) !important;
 	background-repeat: no-repeat !important;
 }

--- a/html_app/ui/microscopy.soy
+++ b/html_app/ui/microscopy.soy
@@ -789,18 +789,25 @@
     </div>
     
 	<div class = 'scb_s_microscopy_lens_controls_section_5'>
-    			<span class='scb_s_microscopy_filter_label'>Filters:</span>
-    					<input class='scb_f_microscopy_red scb_s_microscopy_if' disabled='disabled'  microscopy_id='{$microscopy.id}' title='Red'  name='IF' type="radio" assignment_id='{$assignment.id}'
-				experiment_id='{$experiment.id}' {if $microscopy_line_id}microscopy_lane_id='{$microscopy_line_id}'{/if} {if $microscopy.red_enabled}checked='checked'{/if} {if $microscopy.samples_finished}{else}disabled{/if}>
-				<input class='scb_f_microscopy_blue scb_s_microscopy_if ' disabled='disabled' microscopy_id='{$microscopy.id}' title='Blue' name='IF' type="radio" assignment_id='{$assignment.id}'
-				experiment_id='{$experiment.id}' {if $microscopy_line_id}microscopy_lane_id='{$microscopy_line_id}'{/if} {if $microscopy.blue_enabled}checked='checked'{/if} {if $microscopy.samples_finished}{else}disabled{/if}>
-				<input class='scb_f_microscopy_green scb_s_microscopy_if' disabled='disabled' microscopy_id='{$microscopy.id}' title='Green' name='IF' type="radio" assignment_id='{$assignment.id}'
-				experiment_id='{$experiment.id}' {if $microscopy_line_id}microscopy_lane_id='{$microscopy_line_id}'{/if} {if $microscopy.green_enabled}checked='checked'{/if} {if $microscopy.samples_finished}{else}disabled{/if}>
-				<input class='scb_f_microscopy_all scb_s_microscopy_if' disabled='disabled' microscopy_id='{$microscopy.id}'  title='All' name='IF' type="radio" assignment_id='{$assignment.id}'
-				experiment_id='{$experiment.id}' {if $microscopy_line_id}microscopy_lane_id='{$microscopy_line_id}'{/if} {if $microscopy.merge_enabled}checked='checked'{/if} {if $microscopy.samples_finished}{else}disabled{/if}>
-				<br/>
-
-				<br/>
+	    <span class='scb_s_microscopy_filter_label'>Filters:</span>
+	    <input class='scb_f_microscopy_red scb_s_microscopy_if' disabled='disabled'  microscopy_id='{$microscopy.id}'
+	        title='Red'  name='IF' type="radio" assignment_id='{$assignment.id}'
+	        experiment_id='{$experiment.id}' {if $microscopy_line_id}microscopy_lane_id='{$microscopy_line_id}'{/if}
+	        {if $microscopy.red_enabled}checked='checked'{/if} {if $microscopy.samples_finished}{else}disabled{/if}>
+		<input class='scb_f_microscopy_blue scb_s_microscopy_if ' disabled='disabled' microscopy_id='{$microscopy.id}'
+		    title='Blue' name='IF' type="radio" assignment_id='{$assignment.id}'
+		    experiment_id='{$experiment.id}' {if $microscopy_line_id}microscopy_lane_id='{$microscopy_line_id}'{/if}
+		    {if $microscopy.blue_enabled}checked='checked'{/if} {if $microscopy.samples_finished}{else}disabled{/if}>
+		<input class='scb_f_microscopy_green scb_s_microscopy_if' disabled='disabled' microscopy_id='{$microscopy.id}'
+		    title='Green' name='IF' type="radio" assignment_id='{$assignment.id}'
+			experiment_id='{$experiment.id}' {if $microscopy_line_id}microscopy_lane_id='{$microscopy_line_id}'{/if}
+			{if $microscopy.green_enabled}checked='checked'{/if} {if $microscopy.samples_finished}{else}disabled{/if}>
+		<input class='scb_f_microscopy_merge scb_s_microscopy_if' disabled='disabled' microscopy_id='{$microscopy.id}'
+		    title='Merge' name='IF' type="radio" assignment_id='{$assignment.id}'
+			experiment_id='{$experiment.id}' {if $microscopy_line_id}microscopy_lane_id='{$microscopy_line_id}'{/if}
+			{if $microscopy.merge_enabled}checked='checked'{/if} {if $microscopy.samples_finished}{else}disabled{/if}>
+		<br/>
+		<br/>
     
     </div>
     

--- a/instructor/compiler.py
+++ b/instructor/compiler.py
@@ -332,8 +332,8 @@ def micro_model(a):
                                         'mag': 'N/A'
                                     }
                                 )
-
-                        ret[key]['slides'].append(image_list)
+                        if image_list:
+                            ret[key]['slides'].append(image_list)
                 else:
                     for image in mapping.images.all():
                         ret[key]['slides'].append(

--- a/instructor/ui/constants.js
+++ b/instructor/ui/constants.js
@@ -28,3 +28,6 @@ function addNoise(points, factor) {
   });
   return noisy_points;
 }
+
+FILTERS = ['red', 'blue', 'green', 'merge'];
+FLUORESCENT_TYPES = ['IF', 'DYE-FLU', 'FLUOR'];


### PR DESCRIPTION
#### What are the relevant tickets?

Fix #724 
Fix #722 
#### What's this PR do?

In the student view: Rewrite the microcopy filter controls functionality. Only the filters for which images exist should be enabled and colored. Clicking on a filter updates the corresponding image for that filter.
When switching between tabs each tab saves the last filter the user viewed. 
When viewing a tab for the first time the first available filter should be selected.

To test this, create an assignment with microscopy technique that has Fluorescent analysis types. Experiment with different images sets, uploading images for some filters and not for others.
Then preview the assignment, and perform the experiment.
