### PR TITLE
ab micro: delete image from library

### DIFF
--- a/StarCellBio/urls.py
+++ b/StarCellBio/urls.py
@@ -278,6 +278,11 @@ urlpatterns += patterns(
         name="microscopy_analyze"
     ),
     url(
+        r'^ab/assignments/delete_images/$',
+        instructor_common.delete_images,
+        name="delete_images"
+    ),
+    url(
         r'^ab/assignments/select_images/$',
         instructor_common.select_images,
         name="select_images"

--- a/instructor/common.py
+++ b/instructor/common.py
@@ -1770,6 +1770,26 @@ def facs_histograms_edit(request, assignment, sample_prep, sp):
 @assignment_selected
 @check_assignment_owner
 @login_required
+def delete_images(request):
+    """
+    Remove images from library permanently
+    """
+    pk = request.session['assignment_id']
+    image_pk_list = request.POST.getlist('image_pk_list[]')
+
+    for image_pk in image_pk_list:
+        selected_image = get_object_or_404(
+            models.MicroscopyImage,
+            pk=image_pk,
+            assignment__pk=pk
+        )
+        selected_image.delete()
+    return HttpResponse()
+
+
+@assignment_selected
+@check_assignment_owner
+@login_required
 def select_images(request):
     pk = request.session['assignment_id']
     mapping_id = request.POST.get('mapping_pk')

--- a/instructor/migrations/0032_grouped_images_on_delete.py
+++ b/instructor/migrations/0032_grouped_images_on_delete.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('instructor', '0031_micro_objective'), ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='microscopygroupedimages',
+            name='blue_filter_image',
+            field=models.ForeignKey(
+                related_name='grouped_images_blue',
+                on_delete=django.db.models.deletion.SET_NULL,
+                blank=True,
+                to='instructor.MicroscopyImage',
+                null=True
+            ),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='microscopygroupedimages',
+            name='green_filter_image',
+            field=models.ForeignKey(
+                related_name='grouped_images_green',
+                on_delete=django.db.models.deletion.SET_NULL,
+                blank=True,
+                to='instructor.MicroscopyImage',
+                null=True
+            ),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='microscopygroupedimages',
+            name='merge_filter_image',
+            field=models.ForeignKey(
+                related_name='grouped_images_all',
+                on_delete=django.db.models.deletion.SET_NULL,
+                blank=True,
+                to='instructor.MicroscopyImage',
+                null=True
+            ),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='microscopygroupedimages',
+            name='red_filter_image',
+            field=models.ForeignKey(
+                related_name='grouped_images_red',
+                on_delete=django.db.models.deletion.SET_NULL,
+                blank=True,
+                to='instructor.MicroscopyImage',
+                null=True
+            ),
+            preserve_default=True,
+        ),
+    ]

--- a/instructor/models.py
+++ b/instructor/models.py
@@ -215,25 +215,29 @@ class MicroscopyGroupedImages(models.Model):
         MicroscopyImage,
         related_name='grouped_images_red',
         blank=True,
-        null=True
+        null=True,
+        on_delete=models.SET_NULL
     )
     blue_filter_image = models.ForeignKey(
         MicroscopyImage,
         related_name='grouped_images_blue',
         blank=True,
-        null=True
+        null=True,
+        on_delete=models.SET_NULL
     )
     green_filter_image = models.ForeignKey(
         MicroscopyImage,
         related_name='grouped_images_green',
         blank=True,
-        null=True
+        null=True,
+        on_delete=models.SET_NULL
     )
     merge_filter_image = models.ForeignKey(
         MicroscopyImage,
         related_name='grouped_images_all',
         blank=True,
-        null=True
+        null=True,
+        on_delete=models.SET_NULL
     )
 
 

--- a/instructor/templates/instructor/micro_analyze.html
+++ b/instructor/templates/instructor/micro_analyze.html
@@ -38,6 +38,10 @@
 
           {% endfor %}
         </div>
+        <button type="button" class="scb_s_gray_button scb_ab_s_delete_btn_position scb_ab_f_remove_image"
+                data-pk="{{ mapping_pk }}">
+          DELETE IMAGE(S)
+        </button>
         <button type="button" class="scb_s_gray_button scb_ab_s_save_btn_position scb_ab_f_save_image"
                 data-pk="{{ mapping_pk }}" data-filter_group_id="{{ filter_group_id }}">
           SAVE SELECTION

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -720,6 +720,11 @@ input[type="checkbox"].disabled {
     position:absolute;
     bottom: 30px;
 }
+.scb_ab_s_delete_btn_position{
+    right: 170px;
+    position:absolute;
+    bottom: 30px;
+}
 .scb_ab_s_histogram_selected{
     border: 1px solid indianred;
     box-shadow: 2px 2px 5px indianred;

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -403,7 +403,21 @@ $(function() {
       window.location.reload();
     });
   });
-
+  $('.scb_ab_f_remove_image').click(function () {
+    var data = {};
+    data['image_pk_list'] = _.map($('.scb_ab_s_image_selected'), function (element) {
+      return $(element).attr('id').match(/(\d+)$/)[0];
+    });
+    if (data['image_pk_list'].length > 0) {
+      $.ajax({
+        url: '/ab/assignments/delete_images/',
+        type: "POST",
+        data: data
+      }).then(function () {
+        window.location = '/ab/assignments/microscopy_analyze/';
+      });
+    }
+  });
   /* Save selected list of images to an ImageMapping object*/
   $('.scb_ab_f_save_image').click(function () {
     var data = {};


### PR DESCRIPTION
#### What are the relevant tickets?

Fix #728 
#### What's this PR do?

When in the 'select/upload image' dialog in Microscopy, allow user to delete images from the library permanently.
