### PR TITLE
ab micro: brightfield hide condition

### DIFF
--- a/html_app/ui/microscopy.soy
+++ b/html_app/ui/microscopy.soy
@@ -319,28 +319,30 @@
                 {foreach $condition in $r.lane.cell_treatment.treatment_list.first.conditions[$r.lane.kind]}
                     <!--If there is only one condition, radio button is already checked-->
                     <div class="scb_s_microscopy_condition_wrapper">
-                        <input
-                            class="scb_f_microscopy_select_conditions
-                                {if $r.is_sample_enabled}{else}scb_s_microscopy_dim_conditions{/if}"
-                            microscopy_id='{$microscopy.id}'
-                            assignment_id='{$assignment.id}'
-                            experiment_id='{$experiment.id}' type="radio"
-                            value="{$condition}"
-                            cell_treatment_id='{$r.cell_treatment.id}'
-                            lane_kind="{$r.kind}"
-                            lane_id="{if $r.kind == 'existing'}{$r.lane.id}{/if}"
-                            {if $r.is_sample_enabled and
-                                (
-                                    $r.lane.slide_conditions == $condition or
-                                    length($r.lane.cell_treatment.treatment_list.first.conditions[$r.lane.kind]) == 1
-                                )
-                            }checked="checked"{/if}
-                        />
-                        <span class="scb_s_western_blot_choose_gel_type_input_text
-                            {if not $r.is_sample_enabled} scb_s_microscopy_dim_conditions{/if}"
-                        >
-                            {$assignment.template.micro_kinds[$r.lane.kind].conditions[$condition].name}
-                        </span>
+                        {if $assignment.template.micro_kinds[$r.lane.kind].conditions[$condition].name != ''}
+                            <input
+                                class="scb_f_microscopy_select_conditions
+                                    {if $r.is_sample_enabled}{else}scb_s_microscopy_dim_conditions{/if}"
+                                microscopy_id='{$microscopy.id}'
+                                assignment_id='{$assignment.id}'
+                                experiment_id='{$experiment.id}' type="radio"
+                                value="{$condition}"
+                                cell_treatment_id='{$r.cell_treatment.id}'
+                                lane_kind="{$r.kind}"
+                                lane_id="{if $r.kind == 'existing'}{$r.lane.id}{/if}"
+                                {if $r.is_sample_enabled and
+                                    (
+                                        $r.lane.slide_conditions == $condition or
+                                        length($r.lane.cell_treatment.treatment_list.first.conditions[$r.lane.kind]) == 1
+                                    )
+                                }checked="checked"{/if}
+                            />
+                            <span class="scb_s_western_blot_choose_gel_type_input_text
+                                {if not $r.is_sample_enabled} scb_s_microscopy_dim_conditions{/if}"
+                            >
+                                {$assignment.template.micro_kinds[$r.lane.kind].conditions[$condition].name}
+                            </span>
+                        {/if}
                     </div>
                 {/foreach}
 			{/if}
@@ -511,8 +513,13 @@
                         {if $r.lane.id == $microscopy.selected_lane.id}
                             <span class='scb_s_western_blot_gel_active scb_s_microscopy_slide_tab ' role='tab'>
                                 <div class='scb_s_microscopy_gel_tab_selected'>
+                                {if $microscopy.selected_lane.kinds[$microscopy.selected_lane.kind]
+                                    .conditions[$microscopy.selected_lane.slide_conditions].short_name == ''}
+                                    {$microscopy.selected_lane.kind}
+                                {else}
                                     {$microscopy.selected_lane.kinds[$microscopy.selected_lane.kind]
                                     .conditions[$microscopy.selected_lane.slide_conditions].short_name}
+                                {/if}
                                 </div>
                             </span>
                         <!--unselected lanes for this cell_treatment-->
@@ -520,7 +527,11 @@
                             <div class='scb_s_microscopy_slide_tab' microscopy_id='{$microscopy.id}'
                                 assignment_id='{$assignment.id}' role='tab'
                                 experiment_id='{$experiment.id}' microscopy_lane_id='{$r.lane.id}'>
-                                {$r.lane.kinds[$r.lane.kind].conditions[$r.lane.slide_conditions].short_name}
+                                {if $r.lane.kinds[$r.lane.kind].conditions[$r.lane.slide_conditions].short_name == ''}
+                                    {$r.lane.kind}
+                                {else}
+                                    {$r.lane.kinds[$r.lane.kind].conditions[$r.lane.slide_conditions].short_name}
+                                {/if}
                             </div>
                         {/if}
                     {/if}

--- a/instructor/compiler.py
+++ b/instructor/compiler.py
@@ -444,8 +444,8 @@ def micro_kinds(a):
                 'identifiers': {}
             }
         ret[analysis]['conditions'][condition] = {
-            'name': condition,
-            'short_name': condition
+            'name': condition if analysis != 'BF' else "",
+            'short_name': condition if analysis != 'BF' else ""
         }
     return ret
 

--- a/instructor/migrations/0033_micro_condition_blank.py
+++ b/instructor/migrations/0033_micro_condition_blank.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('instructor', '0032_grouped_images_on_delete'), ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='microscopysampleprep',
+            name='condition',
+            field=models.CharField(
+                max_length=50,
+                null=True,
+                blank=True
+            ),
+            preserve_default=True,
+        ),
+    ]

--- a/instructor/models.py
+++ b/instructor/models.py
@@ -195,7 +195,7 @@ class MicroscopySamplePrep(models.Model):
         choices=MICRO,
         default=MICRO_DEFAULT
     )
-    condition = models.CharField(max_length=50)
+    condition = models.CharField(max_length=50, blank=True, null=True)
     order = models.IntegerField(default=0)
     has_filters = models.BooleanField(default=False)
 

--- a/instructor/templates/instructor/micro_analyze.html
+++ b/instructor/templates/instructor/micro_analyze.html
@@ -71,7 +71,7 @@
 
         <div class="scb_ab_s_row scb_ab_s_grouping_header_row">
           <div class="scb_ab_s_facs_condition_header">
-            {{ analysis }}, {{ condition }}
+            {{ analysis }}{% if analysis != 'Brightfield' %}, {{ condition }} {% endif %}
           </div>
           {% if forloop.counter == 1 %}
             <div class="scb_ab_s_copy_checkbox_container">

--- a/instructor/templates/instructor/micro_sample_prep.html
+++ b/instructor/templates/instructor/micro_sample_prep.html
@@ -25,7 +25,9 @@
                     {{ form.micro_analysis }}
                   </label>
                 </div>
-                <div>{{ form.condition }}</div>
+                <div {% if form.instance.micro_analysis == 'BF' %}style="visibility:hidden"{% endif %}>
+                  {{ form.condition }}
+                </div>
                 <div>{{ form.id }}</div>
                 <div class="delete_checkbox">{{ form.DELETE }}</div>
             </div>

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -231,6 +231,11 @@ $(function() {
     $('select').change(function(){
       var condition_input = $(this).parent().parent().parent().find('input[type="text"]')[0];
       $(condition_input).attr('placeholder', analysis_dict[$(this).val()]);
+      if($(this).val() === 'BF'){
+        $(condition_input).parent().css('visibility', 'hidden');
+      }else{
+        $(condition_input).parent().css('visibility', 'visible');
+      }
     });
   }
 


### PR DESCRIPTION
#### What are the relevant tickets?

Fix #719
#### What's this PR do?

In microscopy 'Sample Prep' page, hide the conditions input box if 'Brightfield' is selected.
In student view, the condition will be blank, and analysis type will be used to label tabs.

![screen shot 2016-09-19 at 12 00 08 pm](https://cloud.githubusercontent.com/assets/7574259/18639040/640a6b1e-7e60-11e6-8302-3e809f9b604a.png)

![screen shot 2016-09-19 at 12 00 36 pm](https://cloud.githubusercontent.com/assets/7574259/18639029/59bb23d8-7e60-11e6-9e9d-ebab392d6b22.png)
