### PR TITLE
Micro: Fix progress bar

### DIFF
--- a/html_app/ui/MicroscopyView.js
+++ b/html_app/ui/MicroscopyView.js
@@ -1917,15 +1917,6 @@ scb.ui.MicroscopyView = function scb_ui_MicroscopyView(gstate) {
       $('.scb_s_microscopy_right_microscopy', '.scb_s_microscopy_view').prop('disabled', false);
     }
 
-    if (kind == 'sample_prep') {
-
-    } else {
-      $('.scb_s_western_blot_progress_gray_bar', '.scb_s_microscopy_view').children().each(function() {
-        console.log($(this).css('left'));
-        $(this).css('left', parseInt($(this).css('left')) - scb.ui.static.MicroscopyView.MAX_BRIGHTNESS + 'px');
-      });
-      $('.scb_s_western_blot_progress_bar', '.scb_s_microscopy_view').css('top', scb.ui.static.MicroscopyView.GRAY_BAR_TOP_OFFSET + 'px');
-    }
     if (!state.microscopy.light_on) {
       $('#brightup').prop('disabled', true);
 

--- a/html_app/ui/microscopy.soy
+++ b/html_app/ui/microscopy.soy
@@ -428,8 +428,6 @@
 */
 {template .prepare_slide}
 
-
-<div class='scb_s_microscopy_tab_content_slide'>
 {if $microscopy.samples_finished}
 {call .display_m_progress}
 {param step:3 /}
@@ -561,7 +559,6 @@
 				{/call}
 		{/if}
  		</div>
-</div>	
 {/template}
 
 /**
@@ -971,7 +968,7 @@
 			<div class='scb_s_western_blot_progress_stripe_bar' style='width: 
 
 						{if $step== 1}20px;{/if}
-				{if $step== 2} 289px;{/if}
+				{if $step== 2} 294px;{/if}
 				{if $step== 3}607px; border-top-right-radius:8px; border-bottom-right-radius:8px;{/if}'
 				
 				 aria-label='


### PR DESCRIPTION
#### What are the relevant tickets?

Fix #738
#### What's this PR do?

Perform an experiment using Microscopy technique. After you click `prepare slides` button you should bee on step 2 `Load`. The progress bar should be fixed:
![screen shot 2016-10-28 at 12 39 18 pm](https://cloud.githubusercontent.com/assets/7574259/19814144/01d1a0ce-9d0b-11e6-9630-8a342744605e.png)
