### PR TITLE
AB Micro: add styles to + buttons

### DIFF
--- a/instructor/templates/instructor/micro_analyze.html
+++ b/instructor/templates/instructor/micro_analyze.html
@@ -127,7 +127,7 @@
                             <img src="{{ filter_image.file.url }}" class="scb_ab_s_small_image"/>
                           {% else %}
                             <button type="button" data-filter_group_id="{{ filter }}-{{ image_set.id }}"
-                                    class="open_upload_window_btn"
+                                    class="open_upload_window_btn scb_s_gray_button scb_ab_s_plus_button"
                                     data-row_id="row-{{ instance.id }}"
                                     data-sample_treatment="{{ analysis }}, {{ condition }}">&#43;</button>
                           {% endif %}

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -841,3 +841,10 @@ label.custom-dropdown {
     position: relative;
     top: 5px;
 }
+
+.scb_ab_s_plus_button{
+    font-size: large;
+    width: 30px;
+    font-family: 'sourcesanspro-semibold';
+    letter-spacing: normal;
+}


### PR DESCRIPTION
#### What are the relevant tickets?
None
#### What's this PR do?
Add styles to plus button in Microscopy `Images`(analyze) page.

<img width="739" alt="screen shot 2016-12-02 at 3 38 59 pm" src="https://cloud.githubusercontent.com/assets/7574259/20849625/9f199eb2-b8a5-11e6-9eab-a1ab42fc5fa8.png">
