### PR TITLE
NSF#2: change order of techniques

### DIFF
--- a/html_app/assignments/scb_ex/assignment.js
+++ b/html_app/assignments/scb_ex/assignment.js
@@ -1545,7 +1545,7 @@ var __scb_sample_2 = {
     ],
     ui: {
       experimental_design: {
-        techniques: ['facs', 'wb'],
+        techniques: ['wb', 'facs'],
         gel_types: ['.10', '.12', '.15']
       },
       experiment_setup: {


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #152
#### What's this PR do?

Change the order of techniques, to fix the position of the divider on the 'Design Page'.

Before testing this, don't forget to delete assignment #2 (or all assignments) from `backend.Assignment`, only then it will create new assignments with the updated template at the time when you go to NSF exercises.
