### PR TITLE
Enable errors when setting up a course

### DIFF
--- a/instructor/common.py
+++ b/instructor/common.py
@@ -210,9 +210,6 @@ def course_setup(request):
     if course_selected:
         return redirect("common_course_modify")
 
-    formset = CourseFormSet(
-        queryset=models.Course.objects.filter(owner=request.user)
-    )
     pages = {'assignment': True, 'course': True}
     return render_to_response(
         'instructor/course_modify.html',
@@ -406,7 +403,11 @@ def course_modify(request):
                     assignment.last_page_name = 'strains'
                 assignment.save()
                 return redirect("common_assignments_edit_strains")
-            return redirect("common_course_modify")
+            if errors:
+                # want to avoid form errors when have other errors
+                formset = CourseFormSet(
+                    queryset=models.Course.objects.filter(owner=request.user)
+                )
     # for view mode
     elif request.method == "POST" and 'continue' in request.POST:
         return redirect("common_assignments_edit_strains")

--- a/instructor/common.py
+++ b/instructor/common.py
@@ -195,6 +195,10 @@ def course_setup(request):
                 # need to set the owner
                 course.owner = user
                 course.save()
+    else:
+        formset = CourseFormSet(
+            queryset=models.Course.objects.filter(owner=request.user)
+        )
 
     # if there is at least one course
     all_courses = models.Course.objects.filter(owner=request.user)


### PR DESCRIPTION
#### What are the relevant tickets?
None.


To test this, create new instructors account. Create an assignment, when setting up the course try to enter a course code that you have used in other accounts. That should show an error. 
Once you created few courses, try to delete them. Course that has assignments associated with it should show error when the user tries to delete it. 