### PR TITLE
Added allowed_hosts setting

### DIFF
--- a/StarCellBio/settings.py
+++ b/StarCellBio/settings.py
@@ -13,6 +13,7 @@ rel = lambda p: os.path.join(SITE_ROOT, p)
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
+ALLOWED_HOSTS = ['*']
 
 import platform
 if platform.node() == 'starapp':


### PR DESCRIPTION
Added the `ALLOWED_HOSTS` setting so that we stop getting erroneous emails about unallowed hosts.