### PR TITLE
Fix Ansible playbook

### DIFF
--- a/provision/ansible-dev.yml
+++ b/provision/ansible-dev.yml
@@ -32,12 +32,12 @@
     - name: Install debian packages
       sudo: yes
       apt: name={{ item }} update_cache=yes
-      with_items: apt_packages
+      with_items: "{{ apt_packages }}"
 
     - name: Install pip packages
       sudo: yes
       pip: name={{ item }}
-      with_items: pip_packages
+      with_items: "{{ pip_packages }}"
 
     - name: Create venv
       shell: >
@@ -91,7 +91,7 @@
 
     - name: Compile files
       shell: >
-        exceutable=/bin/bash
+        executable=/bin/bash
         chdir=/vagrant/html_app
         {{ venv_path }}/bin/python build.py
       environment:


### PR DESCRIPTION
With latest Ansible (2.3.2.0), `ansible-dev.yml` is reported as containing a syntax error. We have to use the Jinja2 templating system to refer to `apt_packages` and `pip_packages` as bare variable names are no longer accepted. Also fixed a typo: `exceutable` should be `executable`.