### PR TITLE
Add assignment text and multiple files upload.

### DIFF
--- a/html_app/ui/assignments.gss
+++ b/html_app/ui/assignments.gss
@@ -151,6 +151,18 @@ background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png')
 	display:block;
 }
 
+.scb_s_display_section li {
+    margin-bottom: 0.5em;
+}
+
+.scb_s_display_section a {
+    color: #316f94;
+}
+
+.scb_s_display_section a:hover {
+    color: #676767;
+}
+
 .scb_assignments_header_link_selected{
 	color:white;
 	background-repeat:no-repeat;

--- a/instructor/compiler.py
+++ b/instructor/compiler.py
@@ -1,4 +1,5 @@
 from django.db.models import Q
+from django.utils.html import format_html, format_html_join
 from instructor.models import (
     Assignment, WesternBlotBands, FlowCytometryHistogramMapping,
     MicroscopyImageMapping
@@ -124,8 +125,8 @@ def compile(assignment_id):
 
     ret['template']['instructions'] = [
         [
-            'Assignment',
-            'Please contact your instructor for your StarCellBio assignment.'
+            a.name,
+            assignment_text_files_html(a)
         ]
     ]
     ret['template']['model'] = {}
@@ -164,6 +165,21 @@ def compile(assignment_id):
         ret['template']['model']['facs'] = facs_model(a)
     return ret
 
+def assignment_text_files_html(assignment):
+    files = json.loads(assignment.files)
+    return assignment_text(assignment.text) + assignment_files(files)
+
+def assignment_text(text):
+    return format_html('<p>{}</p>', text)
+
+def assignment_files(files):
+    if files:
+        return '<ul>' + format_html_join(
+            '', '<li><a href="{}">{}</li>',
+            ((file['url'], file['name']) for file in files)
+        ) + '</ul>'
+    else:
+        return ''
 
 def format_table(assignment):
     headers = "%CELL_LINE%, %TREATMENT%"

--- a/instructor/migrations/0034_upload_assignment_files.py
+++ b/instructor/migrations/0034_upload_assignment_files.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instructor', '0033_micro_condition_blank'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='assignment',
+            name='files',
+            field=models.TextField(default=b''),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='assignment',
+            name='text',
+            field=models.TextField(default=b''),
+            preserve_default=True,
+        ),
+    ]

--- a/instructor/models.py
+++ b/instructor/models.py
@@ -61,6 +61,8 @@ class Assignment(models.Model):
         default='micro_sample_prep'
     )
     name = models.CharField(max_length=50)
+    text = models.TextField(default='')
+    files = models.TextField(default='')
     access = models.CharField(max_length=50, choices=ACCESS, default='private')
     basedOn = models.ForeignKey("Assignment", null=True, blank=True)
     group_by = models.CharField(

--- a/instructor/templates/instructor/assignment_modify.html
+++ b/instructor/templates/instructor/assignment_modify.html
@@ -8,13 +8,11 @@
                {% if not based_on %}checked{% endif %} disabled/>
         <span class='scb_s_assignment_setup_radio_text'>Create new assignment OR</span>
     </div>
-
     <div class='scb_s_assignment_setup_radio_choice'>
         <input class='scb_s_experiment_setup_choose_template_kind' type="radio" name="setup_kind"
                {% if based_on %}checked{% endif %} disabled/>
         <span class='scb_s_assignment_setup_radio_text'>Use an existing assignment as a template.</span>
         <br/>
-
     </div>
     <div class="scb_s_assignment_setup_assignment_list"
          aria-labelledby="scb_s_experiment_step_progress_label_for_assignment">
@@ -31,17 +29,31 @@
     </div>
     <br/>
     <br/>
-
-
-    <div class='scb_s_assignment_setup_course_name_heading'>Change name of this assignment</div>
-
-    <form method="post">{% csrf_token %}
-        {{ form.name }}
-        <div class="scb_s_form_errors">
-            {{ form.name.errors }}
+    <form method="post" enctype="multipart/form-data" class="scb_ab_s_assignment_form">{% csrf_token %}
+        <div class='scb_s_assignment_setup_course_name_heading'>Name</div>
+        <input type="text" name="assignment_name" value="{{ assignment_name }}">
+        <span class="name_error"></span>
+        <div class='scb_s_assignment_setup_course_name_heading'>Assignment Text</div>
+        <textarea
+            name="assignment_text"
+            placeholder="This text will be displayed to students above the assignment files. We recommend that you keep this text short.">{{ assignment_text }}</textarea>
+        <div class='scb_s_assignment_setup_course_name_heading'>Upload Assignment Files</div>
+        <div class="scb_ab_s_file_list">
+            <ul>
+                {% for file in assignment_files %}
+                    <li>
+                        <a href="{{ file.url }}">{{ file.name }}</a>
+                        <button class="scb_s_ab_trash_icon scb_ab_s_delete_file"></button>
+                    </li>
+                {% endfor %}
+            </ul>
         </div>
-
-
+        <div>
+            <label for="files" class="scb_s_gray_button scb_ab_s_add_files_button">
+                ADD FILES
+            </label>
+            <input type="file" name="files" id="files" class="scb_ab_s_add_files_input" multiple>
+        </div>
         <div>
             <input type="submit"
                    name="continue"
@@ -53,6 +65,5 @@
                    value="SAVE"/>
         </div>
     </form>
-
 
 {% endblock %}

--- a/instructor/templates/instructor/assignment_setup.html
+++ b/instructor/templates/instructor/assignment_setup.html
@@ -9,7 +9,6 @@
                {% if not based_on %}checked{% endif %}/>
         <span class='scb_s_assignment_setup_radio_text'>Create new assignment OR</span>
     </div>
-
     <div class='scb_s_assignment_setup_radio_choice'>
         <input class='scb_s_experiment_setup_choose_template_kind scb_f_assignment_setup_radio_existing' type="radio"
                name="setup_kind"
@@ -33,20 +32,27 @@
     </div>
     <br/>
     <br/>
-
-
-    <div class='scb_s_assignment_setup_course_name_heading'>3. What is the name of the assignment?</div>
-
-    <form method="post">{% csrf_token %}
-        <input type="text" name="name" class="" value="{{ assignment_name }}">
+    <form method="post" enctype="multipart/form-data">{% csrf_token %}
+        <div class='scb_s_assignment_setup_course_name_heading'>What is the name of the assignment?</div>
+        <input type="text" name="name" value="{{ assignment_name }}">
+        <div class='scb_s_assignment_setup_course_name_heading'>What text should it display?</div>
+        <textarea
+            name="assignment_text"
+            placeholder="This text will be displayed to students above the assignment files. We recommend that you keep this text short."></textarea>
+        <div class='scb_s_assignment_setup_course_name_heading'>What files would you like to upload?</div>
+        <div class="scb_ab_s_file_list"><ul></ul></div>
+        <div>
+            <label for="files" class="scb_s_gray_button scb_ab_s_add_files_button">
+                ADD FILES
+            </label>
+        </div>
+        <input type="file" name="assignment_files" id="files" class="scb_ab_s_add_files_input_setup" multiple>
         <div class="scb_ab_s_input_error">{{ error }}</div>
         <input type="hidden" name="based_on" id="based_on">
-
         <input type="submit" data-based_on="null"
                name="continue"
                class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
                value="SAVE AND CONTINUE &nbsp; &#9654;"/>
     </form>
-
 
 {% endblock %}

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -11,6 +11,54 @@ input, select { outline: none; }
     padding: 5px;
     display:inline-block;
 }
+.scb_ab_s_input_text_area {
+    font-size: 10pt;
+    font-family: 'sourcesanspro-regular';
+    color: black;
+    margin-left: 27px;
+    margin-top: 10px;
+    padding: 5px;
+    display:inline-block;
+    /* Equivalent to rows = 10, cols = 80 */
+    width: 43em;
+    height: 10em;
+}
+
+.scb_ab_s_add_files_input, .scb_ab_s_add_files_input_setup {
+    width: 0.1px;
+    height: 0.1px;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    z-index: -1;
+}
+
+.scb_ab_s_file_list ul {
+    margin: 5px 0 20px 0;
+}
+
+.scb_ab_s_file_list li {
+    margin-bottom: 0.5em;
+}
+
+.scb_ab_s_file_list a {
+    color: #316f94;
+}
+
+.scb_ab_s_file_list a:hover {
+    color: #676767;
+}
+
+.scb_ab_s_add_files_button {
+    padding: 5px;
+    border: 0;
+    margin-left: 27px;
+}
+
+.scb_ab_s_delete_file {
+    border: 0;
+}
+
 .scb_ab_s_form_select_field{
     font-family: 'sourcesanspro-regular';
     width: 141px;


### PR DESCRIPTION
This PR lets an instructor add these optional features to the opening page of an assignment:

1. Text displayed at the top, just below the title. For the time being, no formatting at all is displayed.
2. Files of any type that can be downloaded by the student. They are displayed in a list of clickable anchors.

![student](https://user-images.githubusercontent.com/1427382/32921421-d6692f5e-cb2d-11e7-80f9-895fef3a8c52.png)

On the instructor side, on initial assignment setup, a text area with a placeholder and an 'Add files' button have been appended. The latter gives the instructor the possibility to add multiple files to the assignment that will only be submitted to the server when the [Save and Continue] button is clicked.

![instructor-initial-setup](https://user-images.githubusercontent.com/1427382/32921453-ef4c639c-cb2d-11e7-94c7-7443af0d2e1d.png)

Once this is done, the assignment setup can still be modified. This time, green trash buttons appear next to each file anchors, giving the possibility to delete them. Additional files can also be added. This list will also be uploaded to the server only if [Save] or [Save and Continue] are clicked.

![instructor-modify-setup](https://user-images.githubusercontent.com/1427382/32921473-080e314e-cb2e-11e7-81fd-fe7e710d3a9b.png)

In the JS file, I aligned myself to the rather unusual convention for naming variables (using underscores) instead of the more common camelcase.
