### PR TITLE
Fix Ansible script

### DIFF
--- a/provision/ansible-dev.yml
+++ b/provision/ansible-dev.yml
@@ -30,12 +30,14 @@
     db_pass: 136a411ed9e8592089444b7164ffaf84
   tasks:
     - name: Install debian packages
-      sudo: yes
+      become: true
+      become_method: sudo
       apt: name={{ item }} update_cache=yes
       with_items: "{{ apt_packages }}"
 
     - name: Install pip packages
-      sudo: yes
+      become: true
+      become_method: sudo
       pip: name={{ item }}
       with_items: "{{ pip_packages }}"
 
@@ -66,11 +68,13 @@
         dest: /vagrant/html_app/js/
 
     - name: Create database
-      sudo: yes
+      become: true
+      become_method: sudo
       mysql_db: name={{ db_name }}
 
     - name: Create user
-      sudo: yes
+      become: true
+      become_method: sudo
       mysql_user: >
         name={{ db_user }}
         password={{ db_pass }}


### PR DESCRIPTION
@idegtiarov @annagav @laleman @pdpinch 

I had to do a full reinstall on my machine and found out the Ansible script would stall with latest version. Reason, the command:

 `sudo: yes`

is deprecated and should be replaced by the following combination:

```
become: true
become_method: sudo
```
Please look at [this](http://docs.ansible.com/ansible/latest/become.html) Ansible doc.