### PR TITLE
Improve a11y

### DIFF
--- a/html_app/ui/common.gss
+++ b/html_app/ui/common.gss
@@ -9,10 +9,6 @@
 .dummy {
 }
 
-#main button, #main *[role=button], input[type=radio] {
-	outline:none !important;
-}
-
 body {
     background-color: #e9edf1;
 }

--- a/instructor/templates/instructor/assignment_modify.html
+++ b/instructor/templates/instructor/assignment_modify.html
@@ -1,7 +1,6 @@
 {% extends "instructor/assignment_sidebar.html" %}
 
 {% block right_side %}
-
     <div class='scb_s_assignment_setup_title'>Assignment Setup</div>
     <div class='scb_s_assignment_setup_radio_choice' aria-label='Create New Assignment'>
         <input class='scb_s_experiment_setup_choose_template_kind' type="radio" name="setup_kind"
@@ -49,21 +48,20 @@
             </ul>
         </div>
         <div>
+            <input type="file" name="files" id="files" class="scb_ab_s_add_files_input" multiple>
             <label for="files" class="scb_s_gray_button scb_ab_s_add_files_button">
                 ADD FILES
             </label>
-            <input type="file" name="files" id="files" class="scb_ab_s_add_files_input" multiple>
         </div>
-        <div>
-            <input type="submit"
-                   name="continue"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE AND CONTINUE &nbsp; &#9654;"/>
+        <div class="scb_ab_s_nav_controls_right">
             <input type="submit"
                    name="save"
                    class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE"/>
+                   value="SAVE">
+            <input type="submit"
+                   name="continue"
+                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                   value="SAVE AND CONTINUE &nbsp; &#9654;">
         </div>
     </form>
-
 {% endblock %}

--- a/instructor/templates/instructor/assignment_select_variables.html
+++ b/instructor/templates/instructor/assignment_select_variables.html
@@ -29,19 +29,20 @@ var created = {{ treatments_created }};
             <div class='scb_ab_f_select_variable scb_ab_s_variable_wrapper'>
                 {{ form.has_collection_time }} Collection Time
             </div>
-            <input type="submit"
-               name="continue"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE AND CONTINUE &nbsp; &#9654;">
-            <input type="submit"
-               name="save"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE"/>
-
-
+            <div class="scb_ab_s_nav_controls scb_ab_s_shift_left">
+                <input type="button"
+                       class="scb_ab_s_navigation_button scb_s_back_btn"
+                       value="&#9664; &nbsp; BACK"
+                       data-location="{% url "common_assignments_edit_strains" %}">
+                <input type="submit"
+                       name="save"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE">
+                <input type="submit"
+                       name="continue"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE AND CONTINUE &nbsp; &#9654;">
+            </div>
         </form>
     </div>
-    <a href="{% url "common_assignments_edit_strains" %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-</a>
 {% endblock %}

--- a/instructor/templates/instructor/assignment_setup.html
+++ b/instructor/templates/instructor/assignment_setup.html
@@ -42,17 +42,18 @@
         <div class='scb_s_assignment_setup_course_name_heading'>What files would you like to upload?</div>
         <div class="scb_ab_s_file_list"><ul></ul></div>
         <div>
+            <input type="file" name="assignment_files" id="files" class="scb_ab_s_add_files_input_setup" multiple>
             <label for="files" class="scb_s_gray_button scb_ab_s_add_files_button">
                 ADD FILES
             </label>
         </div>
-        <input type="file" name="assignment_files" id="files" class="scb_ab_s_add_files_input_setup" multiple>
         <div class="scb_ab_s_input_error">{{ error }}</div>
         <input type="hidden" name="based_on" id="based_on">
-        <input type="submit" data-based_on="null"
-               name="continue"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE AND CONTINUE &nbsp; &#9654;"/>
+        <div class="scb_ab_s_nav_controls_right">
+            <input type="submit" data-based_on="null"
+                   name="continue"
+                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                   value="SAVE AND CONTINUE &nbsp; &#9654;">
+        </div>
     </form>
-
 {% endblock %}

--- a/instructor/templates/instructor/course_modify.html
+++ b/instructor/templates/instructor/course_modify.html
@@ -58,25 +58,20 @@
                 <input type="submit" name="add" class='scb_s_gray_button scb_s_experiment_setup_add_button' value="ADD">
             </div>
         </div>
-        <div>
+        <div class="scb_ab_s_nav_controls">
+            <input type="button"
+                   class="scb_ab_s_navigation_button scb_s_back_btn"
+                   value="&#9664; &nbsp; BACK"
+                   data-location="{% if new %}{% url "common_assignment_setup" %}
+                                  {% else %}{% url "common_assignment_modify" %}{% endif %}">
             <input type="submit"
-                   name="continue"
-                   class=" scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE AND CONTINUE &nbsp; &#9654;"/>
+                    name="save"
+                    class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                    value="SAVE">
             <input type="submit"
-                   name="save"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE"/>
+                    name="continue"
+                    class=" scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                    value="SAVE AND CONTINUE &nbsp; &#9654;">
         </div>
     </form>
-
-    <div>
-
-        <a href="{% if new %}{% url "common_assignment_setup" %}
-            {% else %}{% url "common_assignment_modify" %}{% endif %}">
-            <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-        </a>
-
-    </div>
-
 {% endblock %}

--- a/instructor/templates/instructor/courses.html
+++ b/instructor/templates/instructor/courses.html
@@ -9,7 +9,6 @@
         {% endfor %}
         </div>
         <hr>
-
     {% endfor %}
-<input type="submit" value="Save"/>
+    <input type="submit" value="Save">
 </form>

--- a/instructor/templates/instructor/facs_analyze.html
+++ b/instructor/templates/instructor/facs_analyze.html
@@ -127,7 +127,7 @@
                     <div class="scb_ab_s_histogram_tab_selected">Select Histogram</div>
                     <div class="scb_ab_s_histogram_tab_not_selected">Draw New Histogram</div>
                 </div>
-             <div class="scb_ab_s_draw_new_histogram_content">
+                <div class="scb_ab_s_draw_new_histogram_content">
                     <div class="scb_ab_s_chosen_sample_heading">
                         <div class="scb_ab_s_row scb_ab_s_grouping_header_row">
                             <div class="scb_ab_s_facs_condition_header scb_ab_f_treatment_text">
@@ -136,7 +136,6 @@
                         <div class="scb_ab_s_row scb_ab_f_sample_name">
                         </div>
                     </div>
-
                 </div>
                 <div class="scb_ab_s_canvas_library scb_ab_s_canvas_library_histogram">
                     {% for histogram in all_histograms %}
@@ -147,20 +146,15 @@
                         </div>
 
                     {% endfor %}
-
                 </div>
                 <div class="scb_ab_s_save_btn_position_wrapper">
                     <button class="scb_s_gray_button scb_ab_s_save_btn_position scb_ab_f_save_selected_histogram">
                         SAVE HISTOGRAM
                     </button>
                 </div>
-
             </div>
-
         </div>
     </div><!-- End of hidden window -->
-
-
     <div class="scb_ab_s_heading_div">
         <div class="scb_ab_s_page_title">Analyze</div>
         <div class='scb_ab_s_heading_description'>
@@ -176,16 +170,12 @@
             </div>
             <!-- Instances are grouped by cell_treatment, analysis, condition-->
             {% for cell_treatment, analysis, condition, instance_list in histogram_groups %}
-
                 <div class="scb_ab_s_row scb_ab_s_grouping_header_row">
                     <div class="scb_ab_s_facs_condition_header">
                         {{ cell_treatment }}, {{ analysis }}, {{ condition }}
                     </div>
                 </div>
-
                 {% for instance in instance_list %}
-
-
                     <div class="scb_ab_s_row">
                         <div class="scb_ab_s_col_width_number">{{ forloop.counter }}.</div>
                         <div class="scb_ab_s_col_width_facs_sample">
@@ -212,10 +202,8 @@
                     </div>
                     <!-- display selected histogram, small version  -->
                     <div class="scb_ab_s_row">
-
                     </div>
                     <div class="scb_ab_s_row" style="padding: 10px 0 8px 0">
-
                         <div class="scb_ab_s_col_width_number"></div>
                         <div class="scb_ab_s_col_width_facs_sample">
                             <div class="scb_ab_s_remove_histogram_icon_position">
@@ -223,7 +211,6 @@
                                       role="button" data-cell_treatment="{{ cell_treatment }}"
                                       data-pk="{{ instance.id }}" aria-label="Remove Histogram">×</span>
                             </div>
-
                             <canvas id="canvas-{{ cell_treatment }}_{{ instance.id }}"
                                 class="scb_ab_s_small_canvas">
                             </canvas>
@@ -251,26 +238,28 @@
                     </div>
                 {% endfor %}
             {% endfor %}
-            <input type="submit"
-                   name="continue"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE AND CONTINUE &nbsp; &#9654;">
-            <input type="submit"
-                   name="save"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE"/>
+            <div class="scb_ab_s_nav_controls scb_ab_s_shift_left">
+                <input type="button"
+                       class="scb_ab_s_navigation_button scb_s_back_btn"
+                       value="&#9664; &nbsp; BACK"
+                       data-location="{% url "facs_setup" %}">
+                <input type="submit"
+                       name="save"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE">
+                <input type="submit"
+                       name="continue"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE AND CONTINUE &nbsp; &#9654;">
+            </div>
         </form>
     </div>
-    <a href="{% url "facs_setup" %}">
-        <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-    </a>
     <script type="text/javascript">
-    all_histograms_data = {{ all_histograms_data|safe }}
-    histograms = {{ histograms|safe }};
-    scale = {{ scale|safe }};
-    x_upper_bound = {{ x_upper_bound|safe }};
-    y_upper_bound = {{ y_upper_bound|safe }};
-    paper.install(window);
-
+        all_histograms_data = {{ all_histograms_data|safe }}
+        histograms = {{ histograms|safe }};
+        scale = {{ scale|safe }};
+        x_upper_bound = {{ x_upper_bound|safe }};
+        y_upper_bound = {{ y_upper_bound|safe }};
+        paper.install(window);
     </script>
 {% endblock %}

--- a/instructor/templates/instructor/facs_sample_prep.html
+++ b/instructor/templates/instructor/facs_sample_prep.html
@@ -35,17 +35,20 @@
         <div>
             <input type="submit" name="add" class='scb_s_gray_button scb_ab_s_experiment_setup_add_button' value="ADD">
         </div>
-        <input type="submit"
-               name="continue"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE AND CONTINUE &nbsp; &#9654;">
-        <input type="submit"
-               name="save"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE"/>
+        <div class="scb_ab_s_nav_controls">
+          <input type="button"
+                 class="scb_ab_s_navigation_button scb_s_back_btn"
+                 value="&#9664; &nbsp; BACK"
+                 data-location="{% url back_url %}">
+          <input type="submit"
+                 name="save"
+                 class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                 value="SAVE">
+          <input type="submit"
+                 name="continue"
+                 class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                 value="SAVE AND CONTINUE &nbsp; &#9654;">
+        </div>
     </form>
 </div>
-<a href="{% url back_url %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-</a>
 {% endblock %}

--- a/instructor/templates/instructor/facs_setup.html
+++ b/instructor/templates/instructor/facs_setup.html
@@ -35,18 +35,21 @@
       <div>{{ form.xrange }}</div>
       <div>{{ form.yrange }}</div>
     </div>
-    <input type="submit"
-           name="continue"
-           class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-           value="SAVE AND CONTINUE &nbsp; &#9654;">
-    <input type="submit"
-           name="save"
-           class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-           value="SAVE"/>
+    <div class="scb_ab_s_nav_controls">
+      <input type="button"
+             class="scb_ab_s_navigation_button scb_s_back_btn"
+             value="&#9664; &nbsp; BACK"
+             data-location="{% url "facs_sample_prep" %}">
+      <input type="submit"
+             name="save"
+             class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+             value="SAVE">
+      <input type="submit"
+             name="continue"
+             class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+             value="SAVE AND CONTINUE &nbsp; &#9654;">
+    </div>
   </form>
-  <a href="{% url "facs_sample_prep" %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-  </a>
   <script type="text/javascript">
     paper.install(window);
   </script>

--- a/instructor/templates/instructor/generic_formset.html
+++ b/instructor/templates/instructor/generic_formset.html
@@ -11,7 +11,7 @@
             {% for form in formset %}
                 {{ form.as_p }}
             {% endfor %}
-            <input type="submit" class="scb_s_assignment_setup_save_button scb_s_navigation_button" value="Submit Questions"/>
+            <input type="submit" class="scb_s_assignment_setup_save_button scb_s_navigation_button" value="Submit Questions">
         </form>
     </div>
 {% endblock %}

--- a/instructor/templates/instructor/micro_analyze.html
+++ b/instructor/templates/instructor/micro_analyze.html
@@ -201,20 +201,23 @@
           {% endif %}
         {% endfor %}
       {% endfor %}
-      <input type="submit"
-             name="continue"
-             class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-             value="{{ save_and_continue }} &nbsp; &#9654;">
-      <input type="submit"
-             name="save"
-             class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-             value="SAVE"/>
+      <div class="scb_ab_s_nav_controls scb_ab_s_shift_left">
+        <input type="button"
+               class="scb_ab_s_navigation_button scb_s_back_btn"
+               value="&#9664; &nbsp; BACK"
+               data-location="{% url "microscopy_sample_prep" %}">
+        <input type="submit"
+               name="save"
+               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+               value="SAVE">
+        <input type="submit"
+               name="continue"
+               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+               value="{{ save_and_continue }} &nbsp; &#9654;">
+      </div>
     </form>
   </div>
-  <a href="{% url "microscopy_sample_prep" %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-  </a>
-   <script type="text/javascript">
+  <script type="text/javascript">
     dialog_open = {{ dialog_open|safe }};
   </script>
 {% endblock %}

--- a/instructor/templates/instructor/micro_sample_prep.html
+++ b/instructor/templates/instructor/micro_sample_prep.html
@@ -35,17 +35,20 @@
         <div>
             <input type="submit" name="add" class='scb_s_gray_button scb_ab_s_experiment_setup_add_button' value="ADD">
         </div>
-        <input type="submit"
-               name="continue"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE AND CONTINUE &nbsp; &#9654;">
-        <input type="submit"
-               name="save"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE"/>
+        <div class="scb_ab_s_nav_controls">
+          <input type="button"
+                 class="scb_ab_s_navigation_button scb_s_back_btn"
+                 value="&#9664; &nbsp; BACK"
+                 data-location="{% url back_url %}">
+          <input type="submit"
+                 name="save"
+                 class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                 value="SAVE">
+          <input type="submit"
+                 name="continue"
+                 class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                 value="SAVE AND CONTINUE &nbsp; &#9654;">
+        </div>
     </form>
 </div>
-<a href="{% url back_url %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-</a>
 {% endblock %}

--- a/instructor/templates/instructor/protocols.html
+++ b/instructor/templates/instructor/protocols.html
@@ -111,18 +111,20 @@
                            value="ADD">
                 </div>
             </div>
-
-            <input type="submit"
-                   name="continue"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE AND CONTINUE &nbsp; &#9654;">
-            <input type="submit"
-                   name="save"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE"/>
+            <div class="scb_ab_s_nav_controls">
+                <input type="button"
+                       class="scb_ab_s_navigation_button scb_s_back_btn"
+                       value="&#9664; &nbsp; BACK"
+                       data-location="{% url "common_assignments_variables" %}">
+                <input type="submit"
+                       name="save"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE">
+                <input type="submit"
+                       name="continue"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE AND CONTINUE &nbsp; &#9654;">
+            </div>
         </form>
     </div>
-    <a href="{% url "common_assignments_variables" %}">
-        <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-    </a>
 {% endblock %}

--- a/instructor/templates/instructor/select_technique.html
+++ b/instructor/templates/instructor/select_technique.html
@@ -12,16 +12,16 @@
         {% endif %}
 
     </div>
-    <br/>
-
-    <a href="{% url "common_strain_treatments" %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-
-    </a>
-    <a href="{% url "common_assignments" %}">
-    <button class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn" role='button'
-            {% if not allow_finish %}hidden{% endif %}>
-        SAVE AND FINISH &nbsp; &#9654;
-    </button>
-    </a>
+    <br>
+    <div class="scb_ab_s_nav_controls_left_right">
+        <input type="button"
+               class="scb_ab_s_navigation_button scb_s_back_btn"
+               value="&#9664; &nbsp; BACK"
+               data-location="{% url "common_assignments" %}">
+        <input type="button"
+               class="scb_ab_s_navigation_button scb_s_back_btn"
+               value="SAVE AND FINISH &nbsp; &#9654;"
+               {% if not allow_finish %}hidden{% endif %}
+               data-location="{% url "common_assignments" %}">
+    </div>
 {% endblock %}

--- a/instructor/templates/instructor/strain_protocols.html
+++ b/instructor/templates/instructor/strain_protocols.html
@@ -71,18 +71,20 @@
                     {{ form.id }}
                 </div>
             {% endfor %}
-            <input type="submit"
-                   name="continue"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE AND CONTINUE &nbsp; &#9654;">
-            <input type="submit"
-                   name="save"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE"/>
+            <div class="scb_ab_s_nav_controls scb_ab_s_shift_left">
+                <input type="button"
+                       class="scb_ab_s_navigation_button scb_s_back_btn"
+                       value="&#9664; &nbsp; BACK"
+                       data-location="{% url "common_assignments_edit_treatments" %}">
+                <input type="submit"
+                       name="save"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE">
+                <input type="submit"
+                       name="continue"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE AND CONTINUE &nbsp; &#9654;">
+            </div>
         </form>
     </div>
-    <a href="{% url "common_assignments_edit_treatments" %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-    </a>
-
 {% endblock %}

--- a/instructor/templates/instructor/strains.html
+++ b/instructor/templates/instructor/strains.html
@@ -1,7 +1,6 @@
 {% extends "instructor/assignment_sidebar.html" %}
 
 {% block right_side %}
-
 <div class="scb_ab_s_heading_div">
     <div class="scb_ab_s_page_title">Strains</div>
     <div class='scb_ab_s_heading_description'>
@@ -28,19 +27,22 @@
         <div>
             <input type="submit" name="add" class='scb_s_gray_button scb_ab_s_experiment_setup_add_button' value="ADD">
         </div>
-        <input type="submit"
-               name="continue"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn
-               {% if formset.0.id.value == None %}disabled{% endif %}"
-               value="SAVE AND CONTINUE &nbsp; &#9654;"
-               {% if formset.0.id.value == None %}disabled{% endif %}>
-        <input type="submit"
-               name="save"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE"/>
+        <div class="scb_ab_s_nav_controls">
+          <input type="button"
+                  class="scb_ab_s_navigation_button scb_s_back_btn"
+                  value="&#9664; &nbsp; BACK"
+                  data-location="{% url "common_course_modify" %}">
+          <input type="submit"
+                 name="save"
+                 class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                 value="SAVE">
+          <input type="submit"
+                 name="continue"
+                 class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn
+                 {% if formset.0.id.value == None %}disabled{% endif %}"
+                 value="SAVE AND CONTINUE &nbsp; &#9654;"
+                 {% if formset.0.id.value == None %}disabled{% endif %}>
+        </div>
     </form>
 </div>
-<a href="{% url "common_course_modify" %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-</a>
 {% endblock %}

--- a/instructor/templates/instructor/wb_antibody.html
+++ b/instructor/templates/instructor/wb_antibody.html
@@ -29,17 +29,20 @@
         <div>
             <input type="submit" name="add" class='scb_s_gray_button scb_ab_s_experiment_setup_add_button' value="ADD">
         </div>
-        <input type="submit"
-               name="continue"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE AND CONTINUE &nbsp; &#9654;">
-        <input type="submit"
-               name="save"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE"/>
+        <div class="scb_ab_s_nav_controls">
+            <input type="button"
+                   class="scb_ab_s_navigation_button scb_s_back_btn"
+                   value="&#9664; &nbsp; BACK"
+                   data-location="{% url "western_blot_lysate_type" %}">
+            <input type="submit"
+                   name="save"
+                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                   value="SAVE">
+            <input type="submit"
+                   name="continue"
+                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                   value="SAVE AND CONTINUE &nbsp; &#9654;">
+        </div>
     </form>
 </div>
-<a href="{% url "western_blot_lysate_type" %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-</a>
 {% endblock %}

--- a/instructor/templates/instructor/wb_band_intensity.html
+++ b/instructor/templates/instructor/wb_band_intensity.html
@@ -6,20 +6,14 @@
         <div class='scb_ab_s_heading_description'>
             Define the relative band intensity for each of the proteins detected in your samples and lysate type combinations.
         </div>
-
-
     </div>
     <div class="scb_ab_s_form_container">
         <form method="post">{% csrf_token %}
             {{ formset.management_form }}
-
-
             {% for antibody, form_list in formset_group %}
-
                 <div class="scb_ab_s_antibody_header scb_ab_s_grouping_header_row">
                     {{ antibody.primary }}, {{ antibody.secondary }}
                 </div>
-
                 <div class="scb_ab_s_row scb_ab_s_table_header_text">
                     <div class="scb_ab_s_col_width_wb_sample">Sample</div>
                     <div class="scb_ab_s_col_width_number"></div>
@@ -45,8 +39,6 @@
                             {{ form.instance.strain_protocol.treatment.collection_time.units }}
                         {% endif %}
                         </div>
-
-
                     </div>
                     <div class="scb_ab_s_col_width_type_size">
                         {% if form.instance.lysate_type == 'wc' %} WCL
@@ -66,18 +58,20 @@
                 </div>
                 {% endfor %}
             {% endfor %}
-            <input type="submit"
-                   name="continue"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="{{ save_and_continue }} &nbsp; &#9654;">
-            <input type="submit"
-                   name="save"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE"/>
+            <div class="scb_ab_s_nav_controls scb_ab_s_shift_left">
+                <input type="button"
+                       class="scb_ab_s_navigation_button scb_s_back_btn"
+                       value="&#9664; &nbsp; BACK"
+                       data-location="{% url "western_blot_band_size" %}">
+                <input type="submit"
+                       name="save"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE">
+                <input type="submit"
+                       name="continue"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="{{ save_and_continue }} &nbsp; &#9654;">
+            </div>
         </form>
     </div>
-    <a href="{% url "western_blot_band_size" %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-    </a>
-
 {% endblock %}

--- a/instructor/templates/instructor/wb_band_size.html
+++ b/instructor/templates/instructor/wb_band_size.html
@@ -21,8 +21,6 @@
     <div class="scb_ab_s_form_container">
         <form method="post">{% csrf_token %}
             {{ formset.management_form }}
-
-
             <div class="scb_ab_s_row">
                 <div class="scb_ab_s_antibody_name vertical_align_top">Primary Antibody</div>
                 <div class="scb_ab_s_antibody_name vertical_align_top">Secondary Antibody</div>
@@ -39,7 +37,6 @@
                     {% endif %}
                 </div>
             </div>
-
             {% for form in formset %}
                 <div class="scb_ab_s_row">
                     <div class="scb_ab_s_antibody_name">{{ form.instance.primary }}</div>
@@ -52,18 +49,20 @@
                     {{ form.id }}
                 </div>
             {% endfor %}
-            <input type="submit"
-                   name="continue"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE AND CONTINUE &nbsp; &#9654;">
-            <input type="submit"
-                   name="save"
-                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-                   value="SAVE"/>
+            <div class="scb_ab_s_nav_controls scb_ab_s_shift_left">
+                <input type="button"
+                       class="scb_ab_s_navigation_button scb_s_back_btn"
+                       value="&#9664; &nbsp; BACK"
+                       data-location="{% url "western_blot_antibody" %}">
+                <input type="submit"
+                       name="save"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE">
+                <input type="submit"
+                       name="continue"
+                       class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                       value="SAVE AND CONTINUE &nbsp; &#9654;">
+            </div>
         </form>
     </div>
-    <a href="{% url "western_blot_antibody" %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
-    </a>
-
 {% endblock %}

--- a/instructor/templates/instructor/wb_lysate_type.html
+++ b/instructor/templates/instructor/wb_lysate_type.html
@@ -44,18 +44,20 @@
                 {{ form.has_gel_15 }} 15%
             </div>
         </div>
-
-        <input type="submit"
-               name="continue"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE AND CONTINUE &nbsp; &#9654;">
-        <input type="submit"
-               name="save"
-               class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
-               value="SAVE"/>
-
+        <div class="scb_ab_s_nav_controls">
+            <input type="button"
+                   class="scb_ab_s_navigation_button scb_s_back_btn"
+                   value="&#9664; &nbsp; BACK"
+                   data-location="{% url "common_select_technique" %}">
+            <input type="submit"
+                   name="save"
+                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                   value="SAVE">
+            <input type="submit"
+                   name="continue"
+                   class="scb_ab_s_navigation_button scb_ab_s_nav_continue_btn"
+                   value="SAVE AND CONTINUE &nbsp; &#9654;">
+        </div>
     </form>
-    <a href="{% url "common_select_technique" %}">
-    <button class="scb_ab_s_navigation_button scb_s_back_btn" role='button'>&#9664; &nbsp; BACK</button>
 </a>
 {% endblock %}

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -1,5 +1,11 @@
+*:focus {
+    outline: 2px solid #1c1c1c;
+    outline-offset: 1px;
+}
 
-input, select { outline: none; }
+::-moz-focus-inner {
+    border: 0;
+}
 
 .scb_ab_s_input_text_field{
     font-size: 10pt;
@@ -22,6 +28,11 @@ input, select { outline: none; }
     /* Equivalent to rows = 10, cols = 80 */
     width: 43em;
     height: 10em;
+}
+
+.scb_ab_s_add_files_input:focus + label, .scb_ab_s_add_files_input_setup:focus + label {
+    outline: 2px solid #1c1c1c;
+    outline-offset: 1px;
 }
 
 .scb_ab_s_add_files_input, .scb_ab_s_add_files_input_setup {
@@ -77,36 +88,53 @@ input, select { outline: none; }
     background-color: #f4f6f8;
 }
 
+.scb_ab_s_nav_controls {
+    display: flex;
+    justify-content: space-around;
+}
+
+.scb_ab_s_shift_left {
+    margin-left: -20px;
+}
+
+.scb_ab_s_nav_controls_left_right {
+    display: flex;
+    justify-content: space-between;
+}
+
+.scb_ab_s_nav_controls_left_right > input {
+    margin-left: 15px;
+    margin-right: 15px;
+}
+
+.scb_ab_s_nav_controls_right {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.scb_ab_s_nav_controls_right > input {
+    margin-right: 15px;
+}
+
 .scb_ab_s_navigation_button {
     border: none;
     width: 185px;
     height: 30px;
-    margin: 1px;
     font-size: 10pt;
     font-family: 'sourcesanspro-semibold';
     padding-top: 2px;
-    margin-right: 19px;
-
     border-radius: 8px;
     letter-spacing: 1px;
     background: #27956c;
     color: white;
     text-decoration: none;
     cursor: pointer;
-    padding-left: 13px;
-    padding-right: 9px;
-}
-.scb_ab_s_nav_continue_btn{
-    float: right;
-    margin-top: 100px;
-
 }
 
-.scb_s_back_btn {
+.scb_ab_s_nav_continue_btn, .scb_s_back_btn {
     margin-top: 100px;
-    float: left;
-    margin-left: 20px;
 }
+
 .scb_ab_s_input_error{
     color: indianred;
     display: inline-block;
@@ -687,7 +715,6 @@ input[type="checkbox"].disabled {
     float: right;
     -webkit-appearance: none;
     font-family: 'sourcesanspro-semibold';
-    outline: none;
     height: 26px;
     width: 26px;
     cursor: pointer;

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -69,6 +69,13 @@ $(function() {
   $("form textarea").addClass("scb_ab_s_input_text_area");
   $("form select").addClass("scb_ab_s_form_select_field");
 
+  /**
+   * Back navigation button
+   */
+  $(".scb_s_back_btn").on('click', function() {
+    location = $(this).data('location');
+  });
+
   var file_list = get_file_names(),           // Array of names
       files_to_upload = [],                   // Array of File objects
       files_to_delete = [],                   // Array of urls
@@ -212,7 +219,16 @@ $(function() {
 
   });
   if (typeof (access) !== 'undefined' && access === 'private') {
-    $('.checkbox_form_delete').on('click', function() {
+    var $checkbox_form_delete = $('.checkbox_form_delete');
+    $checkbox_form_delete.attr('tabindex', 0);
+    $checkbox_form_delete.on('keydown', function(event) {
+      // ENTER or SPACE have been pressed
+      if(event.keyCode === 13 || event.keyCode === 32) {
+        event.preventDefault();
+        $(this).trigger('click');
+      }
+    });
+    $checkbox_form_delete.on('click', function() {
       /* Check the hidden checkbox */
       $(this).prev().prop('checked', true);
       /* Want to disable the input box for the strain */


### PR DESCRIPTION
This is a first pass at improving accessibility on the instructor side. Focus outlines were reinstated on most elements. Odd constructs like anchors containing buttons were removed in favor of simple buttons. Tabbing order was corrected for the navigation buttons. Trash icons can now be accessed via keyboard as well as labels associated to file input types.