### PR TITLE
Improve accessibility of the home page

### DIFF
--- a/html_app/instructor/instructor_homepage.soy
+++ b/html_app/instructor/instructor_homepage.soy
@@ -10,42 +10,37 @@ Assignment title
 <div class='scb_s_instructor_header' role='header'>
     <div alt='' class='scb_s_header_line_top' ></div>
 
-    <h1 class='scb_s_logo_h1' aria-label='StarCellBio Home Page Link' ><a aria-hidden='true' href='{if $context.auth and $context.auth.logged_in}#view=assignments{else}#view=homepage{/if}'>StarCellBio<img class='scb_s_logo'
-                                                                       src='images/header/scb_logo.png' 
-                                                                       role='banner'></a></h1>
-    <span class='scb_s_header_tools'>
-        <span class='scb_f_contact' target='_blank' role='link'  aria-label='Contact'>
-            <img class='scb_s_envelope_icon' src='images/header/scb_envelope_icon.png' alt='' role='presentation'>
-        	<span class='scb_s_envelope_text scb_s_header_tools_text'  role='presentation'>
-            CONTACT
-        	</span>
-        </span>
+    <h1 class='scb_s_logo_h1' aria-label='StarCellBio Home Page Link' >
+    	<a aria-hidden='true' href='{if $context.auth and $context.auth.logged_in}#view=assignments{else}#view=homepage{/if}'>
+    		StarCellBio<img class='scb_s_logo' src='images/header/scb_logo.png' role='banner'>
+    	</a>
+    </h1>
+    <div class='scb_s_header_tools'>
+        <button class='scb_f_contact' aria-label='Contact'>
+            <img class='scb_s_header_tools_icon' src='images/header/scb_envelope_icon.png' alt='' role='presentation'>
+        	<span class='scb_s_header_tools_text' role='presentation'>CONTACT</span>
+        </button>
         <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' alt='' role='presentation'>
-        <a class='scb_f_reference' href='/static/ref_lib/full_library.html#'   aria-label='Library' target='_blank'>
-            <img class='scb_s_cabinet_icon' src='images/header/scb_cabinet_icon.png' alt='' role='presentation'>
-            <span class='scb_s_cabinet_text scb_s_header_tools_text' >
-            LIBRARY
-            </span>
+        <a class='scb_f_reference' href='/static/ref_lib/full_library.html#' aria-label='Library' target='_blank'>
+            <img class='scb_s_header_tools_icon' src='images/header/scb_cabinet_icon.png' alt='' role='presentation'>
+            <span class='scb_s_header_tools_text'>LIBRARY</span>
         </a>
         <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' role='presentation'>
-        <!--href='pdf/StarCellBio%20User%20Guide.pdf' target='_blank'-->
-        <span class='scb_f_user_guide' role='link'  aria-label='User Guide' >
-            <img class='scb_s_user_guide_icon' src='images/header/scb_user_guide_icon.png' role='presentation'>
-            <span class='scb_s_user_guide_text scb_s_header_tools_text' role='presentation'  >USER GUIDE</span>
-        </span>
+        <button class='scb_f_user_guide' aria-label='User Guide' >
+            <img class='scb_s_header_tools_icon' src='images/header/scb_user_guide_icon.png' role='presentation'>
+            <span class='scb_s_header_tools_text' role='presentation'>USER<br>GUIDE</span>
+        </button>
         <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' alt='' role='presentation'>
         <a class='scb_f_login' href='#view=assignments' role='presentation' aria-label='Sign In link'>
-        <span class='scb_s_login_status' aria-hidden='true'>        	
-        	{if $context.auth and $context.auth.logged_in}
-        		SIGN OUT
-        	{else}
-        		SIGN IN
-        	{/if}                         
-        </span>
-        
-
+            <span class='scb_s_login_status' aria-hidden='true'>
+            	{if $context.auth and $context.auth.logged_in}
+            		SIGN OUT
+            	{else}
+            		SIGN IN
+            	{/if}
+            </span>
         </a>
-    </span>
+    </div>
 </div>
 {/template}
 

--- a/html_app/ui/homepage.gss
+++ b/html_app/ui/homepage.gss
@@ -73,6 +73,9 @@
     src: url("../fonts/SourceSansPro-SemiboldIt.otf") format("opentype");
 }
 
+*:focus {
+    outline: 2px solid #1c1c1c;
+}
 
 #jqDialog_options button{
 	outline: none !important;
@@ -108,35 +111,65 @@
     width:25%;
 }
 
-
-.scb_s_video_icon{
-position: relative;
-bottom: 5px;
+.scb_s_header_tools {
+    float: rigth;
+    vertical-align: top;
+    display: block;
+    text-align: right;
+    margin-top: -10px;
 }
 
-.scb_s_video_text{
-position: relative;
-bottom: 9px;
-
+.scb_f_contact {
+    background-color: inherit;
+    border: none;
+    font-family: inherit;
+    position: relative;
+    top:-9px;
+    cursor: pointer;
 }
 
-.scb_s_user_guide_icon{
-	margin-left: 5px;
-}
- 
-.scb_s_user_guide_text {
-	margin-right:-15px;
-}
-
-.scb_s_cabinet_icon{
-	margin-left: 5px;
-}
- 
-.scb_s_cabinet_text{
-	padding-right: 0 !important;
+.scb_f_reference {
+    display:inline-block;
+    position: relative;
+    top: -9px;
+    cursor: pointer;
 }
 
-.scb_s_pencil_icon{
+.scb_f_user_guide {
+    background-color: inherit;
+    border: none;
+    font-family: inherit;
+    position: relative;
+    top:-10px;
+    cursor: pointer;
+}
+
+.scb_f_video {
+    display:inline-block;
+    position: relative;
+    bottom: 9px;
+    margin-right: 15px;
+    cursor: pointer;
+}
+
+.scb_f_login {
+    cursor: pointer;
+}
+
+.scb_s_header_tools_text {
+    text-align: left;
+    display: inline-block;
+    vertical-align: middle;
+    font-size: 7.5pt;
+    color: black;
+    padding-left: 6px;
+}
+
+.scb_s_header_tools_icon {
+    vertical-align: middle;
+}
+
+.scb_s_pencil_icon {
 	margin-left: 5px;
 }
 
@@ -144,19 +177,18 @@ bottom: 9px;
 	margin-right:5px;
 }
 
-.scb_s_homepage_see_more_button{
+.scb_s_homepage_see_more_button {
 	cursor: pointer;
 }
 
-
-.scb_s_homepage_new_experiment{
+.scb_s_homepage_new_experiment {
 	left: 750px;
 	width: 150px;
 	bottom: 18px;
 	position: absolute;
 }
 
-.scb_s_new_assignments_experiment{
+.scb_s_new_assignments_experiment {
 	left: 750px;
 	width: 150px;
 	bottom: 27px;
@@ -166,18 +198,6 @@ bottom: 9px;
 .scb_s_logo_h1 {
     display:inline;
     font-size: 0px;
-}
-
-.scb_s_header_tools {
-    float: rigth;
-    vertical-align: top;
-    display: block;
-    text-align: right;
-    margin-top: -10px;
-}
-
-.scb_f_contact, .scb_f_reference, .scb_f_user_guide, .scb_f_login, .scb_f_video{
-	cursor: pointer;
 }
 
 .scb_f_login{
@@ -190,49 +210,14 @@ bottom: 9px;
 	color: #316f94;
 }
 
-
-
-.scb_s_homepage_content{
+.scb_s_homepage_content {
 	margin-top: 12px;
 	margin-left: 20px;
-}
-
-.scb_s_envelope_icon {
-    vertical-align: middle;
-    position: relative;
-    top:-10px;
-}
-
-.scb_s_envelope_text {
-    position: relative;
-    top:-9px;
 }
 
 .scb_s_new_homepage_experiment{
 	position: relative;
 	bottom: 10px;
-}
-
-.scb_s_cabinet_text {
-    position: relative;
-    top: -9px;
-}
-
-.scb_s_user_guide_text {
-    position: relative;
-    top:-2px;
-}
-
-.scb_s_header_tools_text {
-    text-align: left;;
-    display: inline-block;
-    font-size: 7.5pt;
-    color: black;
-    width:40px;
-    padding-left: 6px;
-    padding-right: 6px;
-    padding-top: 4px;
-    padding-bottom: 4px;
 }
 
 .scb_s_header_vertical_line {
@@ -468,7 +453,6 @@ bottom: 9px;
     margin-top: 12px;
     font-family: 'sourcesanspro-bold';
     font-size: 14pt;
-
 }
 
 .scb_s_homepage_technique_title_image {
@@ -604,4 +588,8 @@ a {
 
 .scb_s_homepage_top_left_text b {
 	font-size: 14pt;
+}
+
+.scb_f_try_an_experiment {
+    padding: 0 6px;
 }

--- a/html_app/ui/homepage.soy
+++ b/html_app/ui/homepage.soy
@@ -32,48 +32,43 @@ Assignment title
 <div class='scb_s_header' role='header'>
     <div alt='' class='scb_s_header_line_top' ></div>
 
-    <h1 class='scb_s_logo_h1' aria-label='StarCellBio Home Page Link' ><a aria-hidden='true' href='{if $context.auth and $context.auth.logged_in}#view=assignments{else}#view=homepage{/if}'>StarCellBio<img class='scb_s_logo'
-                                                                       src='images/header/scb_logo.png' 
-                                                                       role='banner'></a></h1>
-    <span class='scb_s_header_tools'>
-        <span class='scb_f_contact' target='_blank' role='link'  aria-label='Contact'>
-            <img class='scb_s_envelope_icon' src='images/header/scb_envelope_icon.png' alt='' role='presentation'>
-        	<span class='scb_s_envelope_text scb_s_header_tools_text'  role='presentation'>
-            CONTACT
-        	</span>
-        </span>
+    <h1 class='scb_s_logo_h1' aria-label='StarCellBio Home Page Link' >
+        <a aria-hidden='true' href='{if $context.auth and $context.auth.logged_in}#view=assignments{else}#view=homepage{/if}'>
+            StarCellBio<img class='scb_s_logo' src='images/header/scb_logo.png' role='banner'>
+        </a>
+    </h1>
+    <div class='scb_s_header_tools'>
+        <button class='scb_f_contact' aria-label='Contact'>
+            <img class='scb_s_header_tools_icon' src='images/header/scb_envelope_icon.png' alt='' role='presentation'>
+        	<span class='scb_s_header_tools_text' role='presentation'>CONTACT</span>
+        </button>
         <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' alt='' role='presentation'>
-        <a class='scb_f_reference' href='/static/ref_lib/full_library.html#'   aria-label='Library' target='_blank'>
-            <img class='scb_s_cabinet_icon' src='images/header/scb_cabinet_icon.png' alt='' role='presentation'>
-            <span class='scb_s_cabinet_text scb_s_header_tools_text' >
-            LIBRARY
-            </span>
+        <a class='scb_f_reference' href='/static/ref_lib/full_library.html#' aria-label='Library' target='_blank'>
+            <img class='scb_s_header_tools_icon' src='images/header/scb_cabinet_icon.png' alt='' role='presentation'>
+            <span class='scb_s_header_tools_text'>LIBRARY</span>
         </a>
         <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' role='presentation'>
-        <!--href='pdf/StarCellBio%20User%20Guide.pdf' target='_blank'-->
-        <span class='scb_f_user_guide' role='link'  aria-label='User Guide' >
-            <img class='scb_s_user_guide_icon' src='images/header/scb_user_guide_icon.png' role='presentation'>
-            <span class='scb_s_user_guide_text scb_s_header_tools_text' role='presentation'  >USER GUIDE</span>
-        </span>
+        <button class='scb_f_user_guide' aria-label='User Guide' >
+            <img class='scb_s_header_tools_icon' src='images/header/scb_user_guide_icon.png' role='presentation'>
+            <span class='scb_s_header_tools_text' role='presentation'>USER<br>GUIDE</span>
+        </button>
     	<img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' role='presentation'>
 		<a class='scb_f_video' href='http://www.youtube.com/playlist?list=PLZhxzzyMIQIHhQ2TOGm3HNLA04ZsTmOLW'
 		    role='link'  aria-label='Videos' target="_blank">
-            <img class='scb_s_video_icon' src='images/header/scb_video_icon.png' role='presentation'>
-            <span class='scb_s_video_text scb_s_header_tools_text' role='presentation'  >VIDEOS</span>
+            <img class='scb_s_header_tools_icon' src='images/header/scb_video_icon.png' role='presentation'>
+            <span class='scb_s_header_tools_text' role='presentation'>VIDEOS</span>
         </a>
         <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' alt='' role='presentation'>
         <a class='scb_f_login' href='#view=assignments' role='presentation' aria-label='Sign In link'>
-        <span class='scb_s_login_status' aria-hidden='true'>        	
-        	{if $context.auth and $context.auth.logged_in}
-        		SIGN OUT
-        	{else}
-        		SIGN IN
-        	{/if}                         
-        </span>
-        
-
+            <span class='scb_s_login_status' aria-hidden='true'>
+            	{if $context.auth and $context.auth.logged_in}
+            		SIGN OUT
+            	{else}
+            		SIGN IN
+            	{/if}
+            </span>
         </a>
-    </span>
+    </div>
 
     <div id='saving'>
         Saving...
@@ -97,34 +92,21 @@ Assignment footer
 			<b>Welcome to StarCellBio,</b><br/> a virtual experiment simulation <br/>tool that teaches the fundamental concepts of cell and molecular <br/>biology, experimental design, and analysis. 
 
 		</span>
-		<!--
-           <span class='scb_s_homepage_see_more_button' role='button'>
-                <img src='images/homepage/SCB_Homepage_SeeMoreBTN.png' alt='See More'>
-           </span>
-        -->
         </span>
         <span class='scb_s_homepage_top_right' role='signup_area'>
-        <!-- 
-    <img class='scb_s_homepage_video_player' src='images/homepage/player_background.png'
-                 alt='Video Player Background'  aria-label='Video Player Background' >
- -->
-            <iframe width="100%" height="194" src="//www.youtube.com/embed/RqDHjjI-GHg" frameborder="0"
-                  allowfullscreen></iframe>
-            <a class='scb_no_underline' href='#view=assignments'>
-                <button class='scb_f_try_an_experiment scb_s_homepage_blue_actions' role='button'>Try an Experiment</button>
+            <iframe width="100%" height="194" src="//www.youtube.com/embed/RqDHjjI-GHg" frameborder="0" allowfullscreen></iframe>
+            <a class='scb_f_try_an_experiment scb_s_homepage_blue_actions scb_no_underline' href='#view=assignments'>
+                Try an Experiment
             </a>
             <img class='scb_s_homepage_blue_line' src='images/homepage/horizontal_line.png' alt=''>
-            <button class='scb_f_create_instructors_account scb_s_homepage_blue_actions' role='button'>Create Instructors
-                Account
+            <button class='scb_f_create_instructors_account scb_s_homepage_blue_actions' role='button'>
+                Create Instructors Account
             </button>
             <img class='scb_s_homepage_blue_line' src='images/homepage/horizontal_line.png' alt=''>
-            <button class='scb_f_create_student_account scb_s_homepage_blue_actions' role='button'>Create Student Account
+            <button class='scb_f_create_student_account scb_s_homepage_blue_actions' role='button'>
+                Create Student Account
             </button>
             <br>
-<!--            <button class='scb_f_instructor_resources scb_s_instructor_resources' alt='INSTRUCTOR RESOURCES'>INSTRUCTOR
-                RESOURCES
-            </button>
--->
         </span>
     </span>
     {call .display_experiment_design}
@@ -183,9 +165,10 @@ Assignment display_experiment_design
                       id='scb_s_homepage_experimental_design_list_info' aria-live='off'>
                     Euismod tincidunt ut laoreet dolore magna kjowkd aliquam erat volu
                 </span>
-                <span href="static/ref_lib/full_library.html#ExperimentalDesign"
-                   class='scb_s_homepage_learn_more scb_s_homepage_technique_learn_more learn_more_dynamic' target='_blank' aria-label='Learn more about this step' role='button'>LEARN
-                    MORE</span>
+                <a href="static/ref_lib/full_library.html#ExperimentalDesign"
+                   class='scb_s_homepage_learn_more scb_s_homepage_technique_learn_more learn_more_dynamic' target='_blank' aria-label='Learn more about this step' role='button'>
+                   LEARN MORE
+                </a>
             </span>
         </span>
         <span class='scb_s_homepage_technique' role='techniques'>

--- a/instructor/templates/instructor/base.html
+++ b/instructor/templates/instructor/base.html
@@ -82,26 +82,26 @@
                     <img class="scb_s_logo" src="images/header/scb_logo.png" role="banner">
                 </a>
             </h1>
-            <span class="scb_s_header_tools">
-                <span class="scb_f_contact" target="_blank" role="link" aria-label="Contact">
-                    <img class="scb_s_envelope_icon" src="images/header/scb_envelope_icon.png" alt="" role="presentation">
-                    <span class="scb_s_envelope_text scb_s_header_tools_text" role="presentation">CONTACT</span>
-                </span>
+            <div class="scb_s_header_tools">
+                <button class="scb_f_contact" aria-label="Contact">
+                    <img class="scb_s_header_tools_icon" src="images/header/scb_envelope_icon.png" alt="" role="presentation">
+                    <span class="scb_s_header_tools_text" role="presentation">CONTACT</span>
+                </button>
                 <img class="scb_s_header_vertical_line" src="images/header/scb_vertical_divider.png" alt="" role="presentation">
                 <a class="scb_f_reference" href="/static/ref_lib/full_library.html#" aria-label="Library" target="_blank">
-                    <img class="scb_s_cabinet_icon" src="images/header/scb_cabinet_icon.png" alt="" role="presentation">
-                    <span class="scb_s_cabinet_text scb_s_header_tools_text">LIBRARY</span>
+                    <img class="scb_s_header_tools_icon" src="images/header/scb_cabinet_icon.png" alt="" role="presentation">
+                    <span class="scb_s_header_tools_text">LIBRARY</span>
                 </a>
                 <img class="scb_s_header_vertical_line" src="images/header/scb_vertical_divider.png" role="presentation">
-                <span class="scb_f_user_guide" role="link" aria-label="User Guide">
-                    <img class="scb_s_user_guide_icon" src="images/header/scb_user_guide_icon.png" role="presentation">
-                    <span class="scb_s_user_guide_text scb_s_header_tools_text" role="presentation">USER GUIDE</span>
-                </span>
+                <button class="scb_f_user_guide" aria-label="User Guide">
+                    <img class="scb_s_header_tools_icon" src="images/header/scb_user_guide_icon.png" role="presentation">
+                    <span class="scb_s_header_tools_text" role="presentation">USER<br>GUIDE</span>
+                </button>
                 <img class="scb_s_header_vertical_line" src="images/header/scb_vertical_divider.png" alt="" role="presentation">
                 <a class="scb_f_login" href="/scb/logout/" role="presentation" aria-label="Sign In link">
                     <span class="scb_s_login_status" aria-hidden="true">SIGN OUT</span>
                 </a>
-            </span>
+            </div>
         </div>
 
         <div class="scb_s_instructor_account_title">Assignment Builder: Beta Version</div>


### PR DESCRIPTION
This is first pass at improving the accessibility of the home page:
* Use anchors instead of spans for actions that lead to a different page.
* Use buttons instead of spans for actions that open a popup.
* Avoid buttons in anchors.
* Adapt related CSS in homepage.gss to reflect the above and remove unused classes.
* Set an outline that is identical to the one reinstated in the instructor application.

All the clickable GUI elements are now accessible via TAB or SHIFT+TAB and will display an outline when receiving focus. That excluded the bottom left `Experimental Design` list that should be coded with list items containing anchors instead of divs.

This is rather simple to test, tab through every element and check that the action is correct when ENTER is pressed for a link and ENTER or SPACE is pressed for a button.

