### PR TITLE
Added settings for travis to use old build instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+dist: trusty
+group: deprecated-2017Q4
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
The updated build instance is causing tests to fail. Attempting to run on the previous host version to resolve failures.

#### What are the relevant tickets?

#### What's this PR do?
Fixes travis builds
#### Where should the reviewer start?
Travis
#### How should this be manually tested?

#### Any background context you want to provide?
The latest image in Travis is causing builds to fail, most likely due to one of the updates of Python or Node. This PR pins the image version to the previous release.
#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?
