### PR TITLE
Fix dialog overlay

### DIFF
--- a/html_app/assignments/scb_ex/addmultipledialog.gss
+++ b/html_app/assignments/scb_ex/addmultipledialog.gss
@@ -9,49 +9,53 @@
 .scb_ex_dialog {
     position: fixed;
     z-index: 999;
-    top:0px;
-    left: 300px;
-    width:800px;
-    height:800px;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     background-color: #80808080;
     font-family: 'sourcesanspro-regular';
-    font-size:10pt;
+    font-size: 10pt;
 }
+
 .scb_ex_samples_table_wrapper{
-    max-height:300px;
-    overflow:auto;
-    position:relative;
+    max-height: 300px;
+    overflow: auto;
+    position: relative;
     border: 1px solid #27956c;
     border-radius: 5px;
     background-color: #edeef2;
 
 }
+
 .scb_ex_samples_table_wrapper::-webkit-scrollbar {
     -webkit-appearance: none;
     width: 7px;
 }
+
 .scb_ex_samples_table_wrapper::-webkit-scrollbar-thumb {
     border-radius: 4px;
     background-color: rgba(0,0,0,.5);
     -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
 }
+
 .scb_ex_samples_table_wrapper > table.scb_s_experiment_setup_table {
     border: 0;
     border-spacing: 0px;
-    width:100%;
+    width: 100%;
     background-color: white;
     padding-bottom: 2px;
 }
+
 .scb_ex_inner_dialog_title_close {
-	
 	padding-top: 0px;
 	float:right;
 	-webkit-appearance: none;
 	font-family:'sourcesanspro-semibold';
-	outline:none;
+	outline: none;
 	height: 26px;
 	width: 26px;
-	cursor:pointer;
+	cursor: pointer;
 	border: none;
 	border-radius: 12px;
 	font-size: 14pt;
@@ -59,21 +63,15 @@
 	background: transparent;
 	background-image: url('../../../images/header/scb_close_button.png');
 	background-repeat: no-repeat;
-
-    
 }
-
 
 .scb_ex_inner_dialog_title_close:hover{
 	background-color: #e58986;
 }
 
-
-
-
 .scb_ex_inner_dialog {
     opacity: 5;
-    width: 75%;
+    width: 50%;
     max-height: 75%;
     overflow: auto;
     margin: 12% auto auto auto;
@@ -84,17 +82,16 @@
 }
 
 .scb_ex_inner_dialog_title {
-    font-size:12pt;
-    color:white;
-    margin:0px;
-    margin-bottom:5px;
+    font-size: 12pt;
+    color: white;
+    margin: 0px;
+    margin-bottom: 5px;
     padding: 6px;
     text-align:left;
     cursor: move;
     @mixin gradient(top,#27956c,#189689,#27956c);
     font-family: 'sourcesanspro-bold';
 }
-
 
 .scb_ex_inner_dialog_body {
     padding: 0 20px;
@@ -118,20 +115,21 @@
 
 .scb_ex_inner_dialog_add, .scb_ex_inner_dialog_cancel {
     margin-left: 10px;
-
 }
+
 .scb_s_clear_all{
     float: right;
 }
+
 .scb_add_samples_add{
     float: right;
     position: relative;
 }
+
 .scb_add_samples_cancel{
     float: right;
     position: relative;
 }
-
 
 .scb_ex_button_float {
     position: relative;


### PR DESCRIPTION
The `Add Samples` button displays, when clicked, a dialog with a gray background overlay that only covers part of the application:

![overlay-before](https://user-images.githubusercontent.com/1427382/34161987-8c972fb6-e4d2-11e7-8d63-05cdc860b0e0.png)

This PR modifies the CSS so that it covers all the application:

![overlay-after](https://user-images.githubusercontent.com/1427382/34162027-a663ed8a-e4d2-11e7-93f9-014ba57cdf0b.png)

Running `build.py` is necessary to see these changes applied.

