### PR TITLE
Student and Instructor accessibility

### DIFF
--- a/auth/templates/uniform/allauth/account/login.html
+++ b/auth/templates/uniform/allauth/account/login.html
@@ -1,92 +1,83 @@
 <style>
+    body {
+        background: #f4f6f8;
+        top:0px;
+        font-size: 10pt;
+        margin: 50px 0px;
+        padding: 0px;
+        text-align: center;
+        position: relative;
+        overflow:hidden;
+    }
 
+    button {
+        font-weight: bold;
+        text-transform: uppercase;
+        background-color: #e0e0e0;
+        border: 1px solid #e0e0e0;
+    }
 
+    .inlineLabels {
+        margin-left: -3px;
+        border: 0;
+    }
 
-body {
-	
-    background: #f4f6f8;
-    top:0px;
-    font-size: 10pt;
-    margin: 50px 0px;
-    padding: 0px;
-    text-align: center;
-    position: relative;
-    overflow:hidden;
-}
-button{
-	font-weight: bold;
-	text-transform: uppercase;
-	background-color: #e0e0e0;
-	border: 1px solid #e0e0e0;
-	
-}
-.inlineLabels{
-margin-left: -3px;
-border:0;
-}
+    #div_id_login > label, #div_id_password > label {
+        color: #316f94;
+        font-size: 9pt;
+        letter-spacing: 1px;
+        font-weight: bold;
+        float: left;
+        display: block;
+        margin-bottom: 5px;
+    }
 
+    #div_id_login > input, #div_id_password > input {
+        display: block;
+        width: 373px;
+        box-shadow: inset 1px 1px 4px 0px gray;
+    }
 
+    #div_id_remember {
+        float: left;
+        margin-left: -7px;
+    }
 
-#div_id_login > label, #div_id_password > label{
-	color: #316f94;
-	font-size: 9pt;
-	letter-spacing: 1px;
-	font-weight: bold;
-	float: left;
-	display:block;
-	margin-bottom: 5px;
-}
+    input {
+        height: 31px;
+        clear: left;
+    }
 
+    .auth_submit_button {
+        float: right;
+        -webkit-appearance: none;
+        border-radius: 8px;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        background: #27956c;
+        height: 27px;
+        color: white;
+        font-size: 9pt;
+        cursor: pointer;
+        position: relative;
+        bottom: 8px;
+        padding-left: 13px;
+        padding-right: 9px;
+        top: 1px;
+    }
 
-#div_id_login > input, #div_id_password > input{
-	display: block;
-	width: 373px;
-	box-shadow: inset 1px 1px 4px 0px gray;
-}
+    .auth_submit_button > div {
+        position: relative;
+        top: 2px;
+    }
 
-
-#div_id_remember{
-	float: left; 
-	margin-left: -7px;
-
-}
-
-input{
-	height: 31px;
-	clear: left;
-}
-
-.auth_submit_button{
-		float:right; 
-		-webkit-appearance:none; 
-		border-radius: 8px; 
-		letter-spacing:1px;
-		text-transform:uppercase;
-		background: #27956c; 
-		height: 27px;
-		color: white;
-		font-size: 9pt; 
-		cursor:pointer;
-		position:relative;
-		bottom: 8px;
-		padding-left: 13px;
-		padding-right: 9px;
-		top:1px;
-}
-
-.auth_submit_button > div{
-	position: relative;
-	top: 2px;
-}
-
-.buttonHolder > a{
-	float: left;
-	font-weight: bold;
-	color: #27956c;
-	font-size: 10pt;
-	text-decoration: none;
-}
-
+    .buttonHolder > a{
+        float: left;
+        font-weight: bold;
+        color: #27956c;
+        font-size: 10pt;
+        text-decoration: none;
+    }
 </style>
 
 {% load url from future %}
@@ -94,56 +85,45 @@ input{
 {% load uni_form_tags %}
 {% load account %}
 
-
 {% block content %}
-{% url 'account_setup' as setup %}
+    {% url 'account_setup' as setup %}
 
-{% if socialaccount.providers  %}
-<p>{% blocktrans with site.name as site_name %}Please sign in with one
-of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a> 
-for a {{site_name}} account and sign in
-below:{% endblocktrans %}</p>
-
-<div class="socialaccount_ballot">
-
-  <ul class="socialaccount_providers">
-    {% include "socialaccount/snippets/provider_list.html" %}
-  </ul>
-
-  <div class="login-or">{% trans 'or' %}</div>
-
-</div>
-
-{% include "socialaccount/snippets/login_extra.html" %}
-
-{% endif %}
-
-
-
-
-<form class="login uniForm" method="POST" action="{% url 'account_login' %}">
- 	{% csrf_token %}
-  <fieldset class="inlineLabels">
-    {{ form|as_uni_form }}
-    {% if redirect_field_value %}
-    <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+    {% if socialaccount.providers  %}
+        <p>
+            {% blocktrans with site.name as site_name %}Please sign in with one
+            of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
+            for a {{site_name}} account and sign in below:{% endblocktrans %}
+        </p>
+        <div class="socialaccount_ballot">
+          <ul class="socialaccount_providers">
+            {% include "socialaccount/snippets/provider_list.html" %}
+          </ul>
+          <div class="login-or">{% trans 'or' %}</div>
+        </div>
+        {% include "socialaccount/snippets/login_extra.html" %}
     {% endif %}
-    <div class="buttonHolder">
-      
-      <button class="primaryAction auth_submit_button login_submit" type="submit" ><div>{% trans "Sign In Now" %}</div></button><br/><br/>
-      <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a><br/><br/>
-	  <a class='not_a_member' href="{% url 'account_signup' %}">{% trans "Not a Member?" %}</a>
-    </div>
-    	
-    	
-  </fieldset>
-</form>
-<script>
-document.getElementById('div_id_login').children[0].textContent='USERNAME';
-document.getElementById('div_id_password').children[0].textContent='PASSWORD';
-</script>
-
+    <form class="login uniForm" method="POST" action="{% url 'account_login' %}">
+        {% csrf_token %}
+        <fieldset class="inlineLabels">
+            {{ form|as_uni_form }}
+            {% if redirect_field_value %}
+                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+            {% endif %}
+            <div class="buttonHolder">
+                <button class="primaryAction auth_submit_button login_submit" type="submit" >
+                    <div>{% trans "Sign In Now" %}</div>
+                </button>
+                <br>
+                <br>
+                <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+                <br>
+                <br>
+                <a class='not_a_member' href="{% url 'account_signup' %}">{% trans "Not a Member?" %}</a>
+            </div>
+        </fieldset>
+    </form>
+    <script>
+        document.getElementById('div_id_login').children[0].textContent='USERNAME';
+        document.getElementById('div_id_password').children[0].textContent='PASSWORD';
+    </script>
 {% endblock %}
-
-
-

--- a/auth/templates/uniform/allauth/account/login.html
+++ b/auth/templates/uniform/allauth/account/login.html
@@ -1,4 +1,9 @@
 <style>
+    *:focus {
+        outline: none;
+        box-shadow: 0 0 2px 2px #1c1c1c;
+    }
+
     body {
         background: #f4f6f8;
         top:0px;
@@ -36,6 +41,12 @@
         display: block;
         width: 373px;
         box-shadow: inset 1px 1px 4px 0px gray;
+        padding-left: 5px;
+    }
+
+    #div_id_login > input:focus, #div_id_password > input:focus {
+        box-shadow: 0 0 2px 2px #1c1c1c;
+        border: none;
     }
 
     #div_id_remember {

--- a/auth/templates/uniform/allauth/account/login.html
+++ b/auth/templates/uniform/allauth/account/login.html
@@ -89,6 +89,10 @@
         font-size: 10pt;
         text-decoration: none;
     }
+
+    .errorField, #errorMsg {
+        color: red;
+    }
 </style>
 
 {% load url from future %}
@@ -134,7 +138,10 @@
         </fieldset>
     </form>
     <script>
-        document.getElementById('div_id_login').children[0].textContent='USERNAME';
-        document.getElementById('div_id_password').children[0].textContent='PASSWORD';
+        // Override labels returned by form (contain a trailing *)
+        document.querySelector('#div_id_login > label').innerHTML = 'USERNAME';
+        document.querySelector('#div_id_password > label').innerHTML  = 'PASSWORD';
+        // Focus on username input
+        document.querySelector('#div_id_login > input').autofocus = true;
     </script>
 {% endblock %}

--- a/auth/templates/uniform/allauth/account/password_reset.html
+++ b/auth/templates/uniform/allauth/account/password_reset.html
@@ -1,80 +1,71 @@
 <style>
+    body {
+        position: absolute;
+        background: #f4f6f8;
+        top: 0px;
+        font-family: 'sourcesanspro-bold';
+        font-size: 10pt;
+        color: #316f94;
+    }
 
-body {
+    .new_password {
+        float: right;
+        -webkit-appearance: none;
+        border-radius: 8px;
+        letter-spacing:1px;
+        text-transform: uppercase;
+        background: #27956c;
+        height: 27px;
+        color: white;
+        font-size: 9pt;
+        cursor: pointer;
+        position: relative;
+        bottom: 8px;
+        padding-left: 13px;
+        padding-right: 9px;
+        top: 1px;
+        border: 0;
+    }
 
-    position: absolute;
-    background: #f4f6f8;
-    top:0px;
-    font-family: 'sourcesanspro-bold';
-    font-size: 10pt;
-    color:#316f94;
-    
-}
-	.new_password{
-		float:right; 
-		-webkit-appearance:none; 
-		border-radius: 8px; 
-		letter-spacing:1px;
-		text-transform:uppercase;
-		background: #27956c; 
-		height: 27px;
-		color: white;
-		font-size: 9pt; 
-		cursor:pointer;
-		position:relative;
-		bottom: 8px;
-		padding-left: 13px;
-		padding-right: 9px;
-		top:1px;
-		border: 0;
+    .inlineLabels {
+        margin-left: -10px;
+        border:0;
+    }
 
-	}
-	
-.inlineLabels{
-margin-left: -10px;
-border:0;
-}
+    ul {
+        padding: 0;
+    }
 
-ul{	
-	padding: 0;
-}
+    ul > a {
+        float: left;
+        font-weight: bold;
+        color: #27956c;
+        font-size: 10pt;
+        text-decoration: none;
+    }
 
-ul > a{
-	float: left;
-	font-weight: bold;
-	color: #27956c;
-	font-size: 10pt;
-	text-decoration: none;
-}
+    #div_id_email > label {
+        color: #316f94;
+        font-size: 9pt;
+        letter-spacing: 1px;
+        font-weight: bold;
+        float: left;
+        display: block;
+        text-transform: uppercase;
+        margin-bottom: 5px;
+    }
 
+    input {
+        height: 31px;
+        clear: left;
+    }
 
-#div_id_email > label{
-	color: #316f94;
-	font-size: 9pt;
-	letter-spacing: 1px;
-	font-weight: bold;
-	float: left;
-	display:block;
-	text-transform: uppercase;
-	margin-bottom: 5px;
-}
-
-
-input{
-	height: 31px;
-	clear: left;
-}
-
-#div_id_email > input{
-
-	display: block;
-	width: 373px;
-	box-shadow: inset 1px 1px 4px 0px gray;
-}
+    #div_id_email > input {
+        display: block;
+        width: 373px;
+        box-shadow: inset 1px 1px 4px 0px gray;
+    }
 </style>
-
-
-
 
 {% extends "account/base.html" %}
 
@@ -85,32 +76,28 @@ input{
 {% block head_title %}{% trans "Password Reset" %}{% endblock %}
 
 {% block content %}
-
-<!-- 
-<h1>{% trans "Password Reset" %}</h1>
- -->
-{% if user.is_authenticated %}
-{% include "account/snippets/already_logged_in.html" %}
-{% endif %}
-<br/>
-<p>{% trans "Enter your e-mail address below and we will send an email to your email address with information on how to reset your password." %}</p>
-
-<form method="POST" action="" class="password_reset uniForm">
-  {% csrf_token %}
-  <fieldset class="inlineLabels">
-    {{ password_reset_form|as_uni_form }}
-    <div class = "buttonHolder">
-      <input class='new_password' type="submit" value="{% trans "Reset My Password" %}" />
-    </div>
-  </fieldset>
-</form>
-
-<!-- 
-<p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
- -->
+    <!--
+    <h1>{% trans "Password Reset" %}</h1>
+     -->
+    {% if user.is_authenticated %}
+        {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
+    <br>
+    <p>{% trans "Enter your e-mail address below and we will send an email to your email address with information on how to reset your password." %}</p>
+    <form method="POST" action="" class="password_reset uniForm">
+        {% csrf_token %}
+        <fieldset class="inlineLabels">
+            {{ password_reset_form|as_uni_form }}
+            <div class = "buttonHolder">
+                <input class='new_password' type="submit" value="{% trans "Reset My Password" %}" />
+            </div>
+        </fieldset>
+    </form>
+    <!--
+    <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+     -->
 {% endblock %}
 
 <script>
-  document.getElementById('div_id_email').children[0].innerHTML='E-MAIL';
-
+    document.getElementById('div_id_email').children[0].innerHTML='E-MAIL';
 </script>

--- a/auth/templates/uniform/allauth/account/password_reset.html
+++ b/auth/templates/uniform/allauth/account/password_reset.html
@@ -76,6 +76,10 @@
         box-shadow: 0 0 2px 2px #1c1c1c;
         border: none;
     }
+
+    .errorField {
+        color: red;
+    }
 </style>
 
 {% extends "account/base.html" %}
@@ -107,8 +111,11 @@
     <!--
     <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
      -->
+    <script>
+        // Override label returned by form (contains a trailing *)
+        document.querySelector('#div_id_email > label').innerHTML='E-MAIL';
+        // Focus on email input
+        document.querySelector('#div_id_email > input').autofocus = true;
+    </script>
 {% endblock %}
 
-<script>
-    document.getElementById('div_id_email').children[0].innerHTML='E-MAIL';
-</script>

--- a/auth/templates/uniform/allauth/account/password_reset.html
+++ b/auth/templates/uniform/allauth/account/password_reset.html
@@ -1,4 +1,9 @@
 <style>
+    *:focus {
+        outline: none;
+        box-shadow: 0 0 2px 2px #1c1c1c;
+    }
+
     body {
         position: absolute;
         background: #f4f6f8;
@@ -64,6 +69,12 @@
         display: block;
         width: 373px;
         box-shadow: inset 1px 1px 4px 0px gray;
+        padding-left: 5px;
+    }
+
+    #div_id_email > input:focus {
+        box-shadow: 0 0 2px 2px #1c1c1c;
+        border: none;
     }
 </style>
 

--- a/auth/templates/uniform/allauth/account/signup.html
+++ b/auth/templates/uniform/allauth/account/signup.html
@@ -1,4 +1,9 @@
 <style>
+    *:focus {
+        outline: none;
+        box-shadow: 0 0 2px 2px #1c1c1c;
+    }
+
     body {
         position: absolute;
         background: #f4f6f8;
@@ -83,6 +88,13 @@
         display: block;
         width: 373px;
         box-shadow: inset 1px 1px 4px 0px gray;
+        padding-left: 5px;
+    }
+
+    #div_id_email > input:focus, #div_id_password1 > input:focus,
+    #div_id_password2 > input:focus, #div_id_course_code > input:focus {
+        box-shadow: 0 0 2px 2px #1c1c1c;
+        border: none;
     }
 </style>
 

--- a/auth/templates/uniform/allauth/account/signup.html
+++ b/auth/templates/uniform/allauth/account/signup.html
@@ -1,100 +1,95 @@
 <style>
+    body {
+        position: absolute;
+        background: #f4f6f8;
+        top: 0px;
+        font-family: 'sourcesanspro-bold';
+        font-size: 10pt;
+        color: #316f94;
+    }
 
-body {
+    .inlineLabels {
+        margin-left: -10px;
+        border: 0;
+    }
 
-    position: absolute;
-    background: #f4f6f8;
-    top:0px;
-    font-family: 'sourcesanspro-bold';
-    font-size: 10pt;
-    color:#316f94;
-    
-}
+    input {
+      height: 31px;
+      clear: left;
+    }
 
-.inlineLabels{
-margin-left: -10px;
-border:0;
-}
+    .auth_submit_button {
+        float: right;
+        -webkit-appearance: none;
+        border-radius: 8px;
+        letter-spacing:1px;
+        text-transform: uppercase;
+        background: #27956c;
+        height: 27px;
+        color: white;
+        font-size: 9pt;
+        cursor: pointer;
+        position: relative;
+        bottom: 8px;
+        padding-left: 13px;
+        padding-right: 9px;
+        top: 1px;
+        border: 0;
+    }
 
+    #errorMsg, #error_1_id_email, #error_1_id_course_code,
+    #error_1_id_password1, #error_1_id_password2 {
+        color: red;
+    }
 
-input{
-	height: 31px;
-	clear: left;
-}
-	
-.auth_submit_button{
-		float:right; 
-		-webkit-appearance:none; 
-		border-radius: 8px; 
-		letter-spacing:1px;
-		text-transform:uppercase;
-		background: #27956c; 
-		height: 27px;
-		color: white;
-		font-size: 9pt; 
-		cursor:pointer;
-		position:relative;
-		bottom: 8px;
-		padding-left: 13px;
-		padding-right: 9px;
-		top:1px;
-		border: 0;
-}
+    .auth_submit_button > div {
+        position: relative;
+        top: 2px;
+    }
 
-#errorMsg, #error_1_id_email, #error_1_id_course_code, #error_1_id_password1, #error_1_id_password2{
-	color: red;
-}
+    #div_id_email > label, #div_id_password1 > label, #div_id_password2 > label,
+    #div_id_course_code > label {
+        color: #316f94;
+        font-size: 9pt;
+        letter-spacing: 1px;
+        font-weight: bold;
+        float: left;
+        display: block;
+        margin-bottom: 5px;
+        text-transform: uppercase;
+    }
 
-.auth_submit_button > div{
-	position: relative;
-	top: 2px;
-}
+    #div_id_account_type > label {
+        color: #316f94;
+        font-size: 9pt;
+        letter-spacing: 1px;
+        font-weight: bold;
+        display: block;
+        margin-bottom: 5px;
+        text-transform: uppercase;
+    }
 
-#div_id_email > label, #div_id_password1 > label, #div_id_password2 > label,
-#div_id_course_code > label{
-	color: #316f94;
-	font-size: 9pt;
-	letter-spacing: 1px;
-	font-weight: bold;
-	float: left;
-	display:block;
-	margin-bottom: 5px;
-	text-transform: uppercase;
-}
+    #id_account_type > li {
+        text-decoration: none;
+         display: inline;
+    }
 
-#div_id_account_type > label{
-	color: #316f94;
-	font-size: 9pt;
-	letter-spacing: 1px;
-	font-weight: bold;
-	display:block;
-	margin-bottom: 5px;
-	text-transform: uppercase;
-}
+    #id_account_type > li > label> input {
+        height:14px;
+    }
 
-#id_account_type >li{
-    text-decoration: none;
-     display: inline;
-}
-#id_account_type >li > label> input{
-    height:14px;
-}
-
-
-#div_id_email > input, #div_id_password1 > input, #div_id_password2 > input,
-#div_id_course_code > input{
-
-	display: block;
-	width: 373px;
-	box-shadow: inset 1px 1px 4px 0px gray;
-}
-
-
-
+    #div_id_email > input, #div_id_password1 > input,
+    #div_id_password2 > input, #div_id_course_code > input {
+        display: block;
+        width: 373px;
+        box-shadow: inset 1px 1px 4px 0px gray;
+    }
 </style>
+
 {% load url from future %}
 {% load i18n %}
 {% load uni_form_tags %}
+
 <div id="toggle_message">
     Your instructor should have provided you with a code that you need
     to enter below to register and use this StarCellBio tool. Please contact
@@ -103,71 +98,61 @@ input{
 </div>
 
 {% block content %}
+    <!--
+    <p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
+     -->
+    <form class="signup uniForm" id="signup_form" method="post" action="{% url 'account_signup' %}">
+        {% csrf_token %}
+        <fieldset class="inlineLabels">
+            {{ form|as_uni_form }}
+            {% if redirect_field_value %}
+                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+            {% endif %}
+            <div id='div_id_course_code'>
+                <label>COURSE CODE </label>
+                <input autocomplete="off" id='id_course_code' name="course_code"  placeholder=''/>
+            </div>
+            <div id='code_status' style='visibility:hidden; display:inline'>
+                <span style='color:red'>&#215; </span>&nbsp; This is not a valid code.
+            </div>
+            <div class="buttonHolder">
+                <button class="primaryAction auth_submit_button" type="submit">{% trans "Create Account" %}</button>
+            </div>
+        </fieldset>
+    </form>
 
-<!-- 
-<p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
- -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var student_type=document.getElementById('id_account_type_0');
+            student_type.addEventListener('click', showStudentForm);
+            var instructor_type = document.getElementById('id_account_type_1');
+            instructor_type.addEventListener('click', showInstructorForm);
+        });
 
-<form class="signup uniForm" id="signup_form" method="post" action="{% url 'account_signup' %}">
-  {% csrf_token %}
-  <fieldset class="inlineLabels">
+        if(document.getElementById('div_id_email').className != 'ctrlHolder error ') {
+            document.getElementById('div_id_email').children[0].textContent='E-MAIL';
+        }
+        if(document.getElementById('div_id_password2').children[0] != 'ctrlHolder error ') {
+            document.getElementById('div_id_password2').children[0].textContent='PASSWORD (AGAIN)';
+        }
 
-    {{ form|as_uni_form }}
+        function showInstructorForm(){
+            var message = "In the instructor account, instructors set up and customize " +
+                    "their own StarCellBio assignments and experiments. The email address " +
+                    "for the instructor account must be different from those used to set " +
+                    "up other StarCellBio accounts. To set up an instructor account, enter " +
+                    "your email and password below and then click Create Account.";
+            document.getElementById('div_id_course_code').style.display = 'none';
+            document.getElementById('toggle_message').innerHTML = message;
+        }
 
-    {% if redirect_field_value %}
-    <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-    {% endif %}
-
-  <div id='div_id_course_code'>
-      <label>COURSE CODE </label>
-      <input autocomplete="off" id='id_course_code' name="course_code"  placeholder=''/>
-  </div>
-
-  <div id='code_status' style='visibility:hidden; display:inline'> <span style='color:red'>&#215; </span>&nbsp; This is not a valid code. </div>
-  <div class="buttonHolder">
-      <button class="primaryAction auth_submit_button" type="submit">{% trans "Create Account" %}</button>
-  </div>
-  </fieldset>
-
-
-</form>
-<script>
-document.addEventListener('DOMContentLoaded', function(){
-    var student_type=document.getElementById('id_account_type_0');
-    student_type.addEventListener('click', showStudentForm);
-    var instructor_type = document.getElementById('id_account_type_1');
-    instructor_type.addEventListener('click', showInstructorForm);
- });
-
-
-if(document.getElementById('div_id_email').className != 'ctrlHolder error ')
-document.getElementById('div_id_email').children[0].textContent='E-MAIL';
-if(document.getElementById('div_id_password2').children[0] != 'ctrlHolder error ')
-document.getElementById('div_id_password2').children[0].textContent='PASSWORD (AGAIN)';
-
-
-function showInstructorForm(){
-    var message = "In the instructor account, instructors set up and customize " +
-            "their own StarCellBio assignments and experiments. The email address " +
-            "for the instructor account must be different from those used to set " +
-            "up other StarCellBio accounts. To set up an instructor account, enter " +
-            "your email and password below and then click Create Account.";
-    document.getElementById('div_id_course_code').style.display = 'none';
-    document.getElementById('toggle_message').innerHTML = message;
-}
-
-function showStudentForm(){
-    var message = 'Your instructor should have provided you with a code that you need ' +
-            'to enter below to register and use this StarCellBio tool. Please contact ' +
-            'your instructor if you have not received this code. You will receive an ' +
-            'email to confirm your account. <br/><br/>Your work will be saved in this account. ';
-    document.getElementById('div_id_course_code').style.display = '';
-    document.getElementById('toggle_message').innerHTML = message;
-}
-
-
-
-
-</script>
-
+        function showStudentForm(){
+            var message = 'Your instructor should have provided you with a code that you need ' +
+                    'to enter below to register and use this StarCellBio tool. Please contact ' +
+                    'your instructor if you have not received this code. You will receive an ' +
+                    'email to confirm your account. <br/><br/>Your work will be saved in this account. ';
+            document.getElementById('div_id_course_code').style.display = '';
+            document.getElementById('toggle_message').innerHTML = message;
+        }
+    </script>
 {% endblock %}

--- a/auth/templates/uniform/allauth/account/signup.html
+++ b/auth/templates/uniform/allauth/account/signup.html
@@ -141,13 +141,6 @@
             instructor_type.addEventListener('click', showInstructorForm);
         });
 
-        if(document.getElementById('div_id_email').className != 'ctrlHolder error ') {
-            document.getElementById('div_id_email').children[0].textContent='E-MAIL';
-        }
-        if(document.getElementById('div_id_password2').children[0] != 'ctrlHolder error ') {
-            document.getElementById('div_id_password2').children[0].textContent='PASSWORD (AGAIN)';
-        }
-
         function showInstructorForm(){
             var message = "In the instructor account, instructors set up and customize " +
                     "their own StarCellBio assignments and experiments. The email address " +
@@ -166,5 +159,12 @@
             document.getElementById('div_id_course_code').style.display = '';
             document.getElementById('toggle_message').innerHTML = message;
         }
+        // Override labels returned by form (contain a trailing *)
+        document.querySelector('#div_id_account_type > label').innerHTML = 'ACCOUNT TYPE';
+        document.querySelector('#div_id_email > label').innerHTML = 'E-MAIL';
+        document.querySelector('#div_id_password1 > label').innerHTML  = 'PASSWORD';
+        document.querySelector('#div_id_password2 > label').innerHTML  = 'PASSWORD (AGAIN)';
+        // Focus on email input
+        document.querySelector('#div_id_email > input').autofocus = true;
     </script>
 {% endblock %}

--- a/html_app/assignments/scb_ex/AddMultipleDialog.js
+++ b/html_app/assignments/scb_ex/AddMultipleDialog.js
@@ -151,7 +151,7 @@ scb_ex1.register = function(dialog, state) {
     scb_ex1.static.scb_ex_inner_dialog_add_assignment_builder(this, dialog, state);
     $(this).focus();
   });
-
+  $('.scb_ex_inner_dialog_title_close').focus();
 }
 
 scb_ex1.setup = function(state) {

--- a/html_app/assignments/scb_ex/addmultipledialog.gss
+++ b/html_app/assignments/scb_ex/addmultipledialog.gss
@@ -75,7 +75,7 @@
     overflow: auto;
     margin: 12% auto auto auto;
     position: relative;
-    border: 5px solid white;
+    border: 2px solid #8d97a3;
     border-radius: 9px;
     background-color: #f5f5f5;
 }

--- a/html_app/assignments/scb_ex/addmultipledialog.gss
+++ b/html_app/assignments/scb_ex/addmultipledialog.gss
@@ -18,14 +18,13 @@
     font-size: 10pt;
 }
 
-.scb_ex_samples_table_wrapper{
+.scb_ex_samples_table_wrapper {
     max-height: 300px;
     overflow: auto;
     position: relative;
     border: 1px solid #27956c;
     border-radius: 5px;
     background-color: #edeef2;
-
 }
 
 .scb_ex_samples_table_wrapper::-webkit-scrollbar {
@@ -48,25 +47,25 @@
 }
 
 .scb_ex_inner_dialog_title_close {
-	padding-top: 0px;
-	float:right;
-	-webkit-appearance: none;
-	font-family:'sourcesanspro-semibold';
-	outline: none;
-	height: 26px;
-	width: 26px;
-	cursor: pointer;
-	border: none;
-	border-radius: 12px;
-	font-size: 14pt;
-	color: transparent;
-	background: transparent;
-	background-image: url('../../../images/header/scb_close_button.png');
-	background-repeat: no-repeat;
+    padding-top: 0px;
+    float:right;
+    -webkit-appearance: none;
+    font-family:'sourcesanspro-semibold';
+    outline: none;
+    height: 26px;
+    width: 26px;
+    cursor: pointer;
+    border: none;
+    border-radius: 12px;
+    font-size: 14pt;
+    color: transparent;
+    background: transparent;
+    background-image: url('../../../images/header/scb_close_button.png');
+    background-repeat: no-repeat;
 }
 
-.scb_ex_inner_dialog_title_close:hover{
-	background-color: #e58986;
+.scb_ex_inner_dialog_title_close:hover {
+    background-color: #e58986;
 }
 
 .scb_ex_inner_dialog {
@@ -77,8 +76,8 @@
     margin: 12% auto auto auto;
     position: relative;
     border: 5px solid white;
-	border-radius: 9px;
-	background-color: #f5f5f5;
+    border-radius: 9px;
+    background-color: #f5f5f5;
 }
 
 .scb_ex_inner_dialog_title {
@@ -87,7 +86,7 @@
     margin: 0px;
     margin-bottom: 5px;
     padding: 6px;
-    text-align:left;
+    text-align: left;
     cursor: move;
     @mixin gradient(top,#27956c,#189689,#27956c);
     font-family: 'sourcesanspro-bold';
@@ -117,16 +116,16 @@
     margin-left: 10px;
 }
 
-.scb_s_clear_all{
+.scb_s_clear_all {
     float: right;
 }
 
-.scb_add_samples_add{
+.scb_add_samples_add {
     float: right;
     position: relative;
 }
 
-.scb_add_samples_cancel{
+.scb_add_samples_cancel {
     float: right;
     position: relative;
 }

--- a/html_app/assignments/scb_ex/addmultipledialog.soy
+++ b/html_app/assignments/scb_ex/addmultipledialog.soy
@@ -8,9 +8,9 @@
 {template .dialog}
 <div class='scb_ex_inner_dialog' role='dialog' aria-label='Add Samples'>
     <h1 class='scb_ex_inner_dialog_title' role='presentation' aria-label='Add Samples'>
-        <span class='scb_ex_inner_dialog_title_close' role='button' aria-label='Close Add Samples'>&#215;</span>
-        Add Samples </h1>
-
+        Add Samples
+        <button class='scb_ex_inner_dialog_title_close' aria-label='Close Add Samples'></button>
+    </h1>
     <div class='scb_ex_inner_dialog_body'>
         <div class='scb_ex_samples_table_wrapper'>
         <table class="scb_s_experiment_setup_table" role='grid' >
@@ -85,8 +85,9 @@
 {template .dialog_assignment_builder}
 <div class='scb_ex_inner_dialog' role='dialog' aria-label='Add Samples'>
     <h1 class='scb_ex_inner_dialog_title' role='presentation' aria-label='Add Samples'>
-        <span class='scb_ex_inner_dialog_title_close' role='button' aria-label='Close Add Samples'>&#215;</span>
-        Add Samples</h1>
+        Add Samples
+        <button class='scb_ex_inner_dialog_title_close' aria-label='Close Add Samples'></button>
+    </h1>
 
     <div class='scb_ex_inner_dialog_body'>
         <div class='scb_ex_samples_table_wrapper'>

--- a/html_app/build.py
+++ b/html_app/build.py
@@ -45,7 +45,7 @@ JS_SUFFIX = '" charset="UTF-8"></script>\n'
 
 HTML_PREFIX = """
 <!DOCTYPE html>
-<html>
+<html lang='en-US'>
   <head>
     <META http-equiv='Content-Type' content='text/html; charset=UTF-8'>
     <meta http-equiv='content-type' content='text/html; charset=utf-8'>

--- a/html_app/build.py
+++ b/html_app/build.py
@@ -173,6 +173,11 @@ def processor(path):
         outfile = "{}/gen/{}.css".format(
             os.path.dirname(infile), os.path.basename(infile)
         )
+        unrecognized_properties = ["outline-offset"]
+        params = []
+        for prop in unrecognized_properties:
+            params += ["--allowed-unrecognized-property", prop]
+        params += ["--pretty-print", infile, "-o", outfile]
 
         # Create directory for output
         try:
@@ -180,13 +185,8 @@ def processor(path):
         except OSError:  # directory already exists
             pass
 
-        call(
-            [
-                "java", "-jar", os.path.join(
-                    REPO_ROOT, "tools/closure-stylesheets-20111230.jar"
-                ), "--pretty-print", infile, "-o", outfile
-            ]
-        )
+        command = ["java", "-jar", os.path.join(REPO_ROOT, "tools/closure-stylesheets-20111230.jar")]
+        call(command + params)
         print "compile gss {} to {} ".format(infile, outfile)
     if update_index:
         global_update_index = True

--- a/html_app/contact/contact.html
+++ b/html_app/contact/contact.html
@@ -1,101 +1,90 @@
+<!DOCTYPE html>
 <html>
-<head>
+    <head>
+        <style>
+            input[type=text] {
+                height: 31px;
+                clear: left;
+                display: block;
+                width: 373px;
+                box-shadow: inset 1px 1px 4px 0px gray;
+            }
 
-</head>
+            .radios >input{
+                margin-left: 20px;
+            }
 
-<body>
-<style>
+            body {
 
+                position: absolute;
+                background: #f4f6f8;
+                top: 0px;
+                font-family: 'sourcesanspro-bold';
+                font-size: 10pt;
+                color: #316f94;
+            }
 
-input[type=text]{
-	height: 31px;
-	clear: left;
-	display: block;
-	width: 373px;
-	box-shadow: inset 1px 1px 4px 0px gray;
-}
+            label {
+                color: #316f94;
+                font-size: 9pt;
+                letter-spacing: 1px;
+                font-weight: bold;
+                float: left;
+                display: block;
+                margin-bottom: 5px;
+                text-transform: uppercase;
+            }
 
-.radios >input{
-	margin-left: 20px;
-}
-
-body {
-
-    position: absolute;
-    background: #f4f6f8;
-    top:0px;
-    font-family: 'sourcesanspro-bold';
-    font-size: 10pt;
-    color:#316f94;
-    
-}
-
-label{
-	color: #316f94;
-	font-size: 9pt;
-	letter-spacing: 1px;
-	font-weight: bold;
-	float: left;
-	display:block;
-	margin-bottom: 5px;
-	text-transform:uppercase;
-
-}
-
-.scb_f_contact_submit_button {
-		float:right; 
-		-webkit-appearance:none; 
-		border-radius: 8px; 
-		letter-spacing:1px;
-		text-transform:uppercase;
-		background: #27956c; 
-		height: 27px;
-		color: white;
-		font-size: 9pt; 
-		cursor:pointer;
-		position:relative;
-		bottom: 8px;
-		padding-left: 13px;
-		padding-right: 9px;
-		top:1px;
-		border: 0;
-}
-
-</style>
-	<form class='scb_f_contact_form' action="/scb/contact" method="post">
-              <fieldset class='scb_f_fieldset'>
-                <input id="project" name="project" type="hidden" value="StarCellBio"> <input id="source" name="source" type="hidden" value="app"> 
-
-                  <label>Your name (optional):</label> <br><input name="name" size="25/" type="text">
-                <br>
-                	<label>Email (optional):</label> <br><input onkeyup="changeCheck()"  id='scb_f_contact_email' name="email" type="text">
-				<br>
-				<span>
-                  <label>May we contact you via email?</label>
-                  <input id='scb_f_check_email' name="subscribe" type="checkbox"></span><br><br>
-
-                  <label>Report type:</label><br>
-                  <div class='radios'><br>
+            .scb_f_contact_submit_button {
+                float:right;
+                -webkit-appearance: none;
+                border-radius: 8px;
+                letter-spacing: 1px;
+                text-transform:uppercase;
+                background: #27956c;
+                height: 27px;
+                color: white;
+                font-size: 9pt;
+                cursor:pointer;
+                position:relative;
+                bottom: 8px;
+                padding-left: 13px;
+                padding-right: 9px;
+                top: 1px;
+                border: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <form class='scb_f_contact_form' action="/scb/contact" method="post">
+            <fieldset class='scb_f_fieldset'>
+                <input id="project" name="project" type="hidden" value="StarCellBio"> <input id="source" name="source" type="hidden" value="app">
+                <label>Your name (optional):</label><br>
+                <input name="name" size="25/" type="text"><br>
+                <label>Email (optional):</label><br>
+                <input onkeyup="changeCheck()"  id='scb_f_contact_email' name="email" type="text"><br>
+                <span>
+                    <label>May we contact you via email?</label>
+                    <input id='scb_f_check_email' name="subscribe" type="checkbox">
+                </span><br><br>
+                <label>Report type:</label><br><br>
+                <div class='radios'>
                   <input name="report" type="radio" value="Bug">Bug<br>
                   <input name="report" type="radio" value="Feature">Feature request<br>
                   <input name="report" type="radio" value="Comment">Comment<br>
                   <input name="report" type="radio" value="Question">Question
-                  </div>
-					<br>
-                  <label>Comment:</label><br>
-                  <textarea cols="40" name="note" rows="10" style="width: 100%;"></textarea><p/>
-
+                </div><br>
+                <label>Comment:</label><br>
+                <textarea cols="40" name="note" rows="10" style="width: 100%;"></textarea><p/>
                 <input class='scb_f_contact_submit_button' type="submit" value="Submit">
-              </fieldset>
-            </form>
-</body>
-<script>
-function changeCheck(){
-	if(document.getElementById('scb_f_contact_email').value.length > 0)
-		document.getElementById('scb_f_check_email').checked = true;
-
-}
-
-</script>
-
+          </fieldset>
+        </form>
+        <script>
+            function changeCheck(){
+                if(document.getElementById('scb_f_contact_email').value.length > 0) {
+                    document.getElementById('scb_f_check_email').checked = true;
+                }
+            }
+        </script>
+    </body>
 </html>

--- a/html_app/contact/contact.html
+++ b/html_app/contact/contact.html
@@ -2,12 +2,23 @@
 <html>
     <head>
         <style>
+            *:focus {
+                outline: none;
+                box-shadow: 0 0 2px 2px #1c1c1c;
+            }
+
             input[type=text] {
                 height: 31px;
                 clear: left;
                 display: block;
                 width: 373px;
+                border: none;
                 box-shadow: inset 1px 1px 4px 0px gray;
+            }
+
+            input[type=text]:focus {
+                box-shadow: 0 0 2px 2px #1c1c1c;
+                border: none;
             }
 
             .radios >input{
@@ -60,7 +71,7 @@
             <fieldset class='scb_f_fieldset'>
                 <input id="project" name="project" type="hidden" value="StarCellBio"> <input id="source" name="source" type="hidden" value="app">
                 <label>Your name (optional):</label><br>
-                <input name="name" size="25/" type="text"><br>
+                <input name="name" size="25/" type="text" autofocus><br>
                 <label>Email (optional):</label><br>
                 <input onkeyup="changeCheck()"  id='scb_f_contact_email' name="email" type="text"><br>
                 <span>
@@ -69,7 +80,7 @@
                 </span><br><br>
                 <label>Report type:</label><br><br>
                 <div class='radios'>
-                  <input name="report" type="radio" value="Bug">Bug<br>
+                  <input name="report" type="radio" value="Bug" checked>Bug<br>
                   <input name="report" type="radio" value="Feature">Feature request<br>
                   <input name="report" type="radio" value="Comment">Comment<br>
                   <input name="report" type="radio" value="Question">Question

--- a/html_app/css/jqdialog.css
+++ b/html_app/css/jqdialog.css
@@ -1,69 +1,43 @@
-
-
-
 #jqDialog_box {
-	background: #f5f5f5;
-	position: absolute;
-	font-family: Arial;
-	z-index:999;
-	min-width: 301px;
-	
-	border-width: 1px 3px 3px 1px;
-	border-style: solid;
-	border:none;
-	border: 5px solid white;
-	-moz-border-radius: 9px;
-	-webkit-border-radius: 9px;
-	-khtml-border-radius: 9px;
-	border-radius: 9px;
-	
-	-moz-box-shadow: 0 0 30px #e6e6e6;
+    background: #f5f5f5;
+    position: absolute;
+    font-family: Arial;
+    z-index:999;
+    min-width: 301px;
+    border-width: 1px 3px 3px 1px;
+    border-style: solid;
+    border:none;
+    border: 5px solid white;
+    -moz-border-radius: 9px;
+    -webkit-border-radius: 9px;
+    -khtml-border-radius: 9px;
+    border-radius: 9px;
+    -moz-box-shadow: 0 0 30px #e6e6e6;
 }
+
 #jqDialog_content {
-	font-weight: bold;
-	font-size: 12px;
-	overflow: hidden;
-	padding: 5px;
-	
+    font-weight: bold;
+    font-size: 12px;
+    overflow: hidden;
+    padding: 5px;
 }
 
 #jqDialog_options {
-	margin: 10px;
-	text-align: center;
+    margin: 10px;
+    text-align: center;
 }
-/* 
-text-align: center;
-#jqDialog_options button {
-	font-family: Arial;
-	margin-right: 5px;#f4f6f8
-	background: #000;
-	border: 0px;
-
-	font-size: 1.5em;
-	color: #fff;
-	width: auto;
-	
-	cursor: pointer;
-	
-	-moz-border-radius: 3px;
-	-webkit-border-radius: 3px;
-	-khtml-border-radius: 3px;
-	border-radius: 3px;
-}
- */
 
 #jqDialog_input {
-	padding: 4px;
-	width: 250px;
+    padding: 4px;
+    width: 250px;
 }
+
 #jqDialog_close {
-	background: none;
-	border: none;
-	float: right;
-	font-weight: bold;
-	font-size: 10px;
-	color: #ff0000;
-	cursor: pointer;
+    background: none;
+    border: none;
+    float: right;
+    font-weight: bold;
+    font-size: 10px;
+    color: #ff0000;
+    cursor: pointer;
 }
-
-

--- a/html_app/css/jqdialog.css
+++ b/html_app/css/jqdialog.css
@@ -4,10 +4,7 @@
     font-family: Arial;
     z-index:999;
     min-width: 301px;
-    border-width: 1px 3px 3px 1px;
-    border-style: solid;
-    border:none;
-    border: 5px solid white;
+    border: 2px solid #8d97a3;
     -moz-border-radius: 9px;
     -webkit-border-radius: 9px;
     -khtml-border-radius: 9px;

--- a/html_app/instructor/instructor_homepage.gss
+++ b/html_app/instructor/instructor_homepage.gss
@@ -106,7 +106,6 @@
     text-align: justify;
     display: inline-block;
     vertical-align: top;
-    min-height:350px;
     background: #e9ecf1;
     border-radius: 8px;
     padding: 10px;

--- a/html_app/ui/AssignmentsView.js
+++ b/html_app/ui/AssignmentsView.js
@@ -8,11 +8,10 @@ if (typeof (scb.ui) == 'undefined') {
 scb.ui.static = scb.ui.static || {};
 scb.ui.static.AssignmentsView = scb.ui.static.AssignmentsView || {};
 
-
-scb.ui.static.AssignmentsView.ARROW_OFFSET = 15;
-scb.ui.static.AssignmentsView.ARROW_DIVISION = 2;
-scb.ui.static.AssignmentsView.HEADER_WIDTH = 579;
+scb.ui.static.AssignmentsView.HEADER_WIDTH = 657;
 scb.ui.static.AssignmentsView.HEADER_OFFSET = 34;
+scb.ui.static.AssignmentsView.BUTTON_WIDTH = 0;
+scb.ui.static.AssignmentsView.BUTTON_LEFT = 0;
 
 
 
@@ -30,34 +29,37 @@ scb.ui.static.AssignmentsView.parse = function(element) {
   return parsed;
 }
 
-scb.ui.static.AssignmentsView.scb_assignments_header_link_wrapper = function(element, workarea) {
+scb.ui.static.AssignmentsView.scb_s_assignments_header_btn = function(element, workarea) {
   var parsed = scb.ui.static.AssignmentsView.parse(element);
   $('.scb_s_assignment_scroll', '.scb_s_assignments_view').scrollTop(0);
   var first_element = $('.scb_s_assignments_slider_header', '.scb_s_assignments_view').children().first().next().get(0);
   var last_element = $('.scb_s_assignments_slider_header', '.scb_s_assignments_view').children().last().prev().get(0);
 
   var section = $(element).attr('value');
-  $('.scb_assignments_header_link_wrapper').removeClass('scb_assignments_header_link_selected');
-  $('.arrow-down-blue').detach();
-  $(element).append('<div class="arrow-down-blue"></div>');
-  $(element).addClass('scb_assignments_header_link_selected');
+  $('.scb_s_assignments_header_btn').removeClass('scb_s_assignments_header_btn_selected');
+  $('.arrow_down_blue_background, .arrow_down_blue_border').detach();
+  $(element).append(
+    '<span class="arrow_down_blue_background"></span>',
+    '<span class="arrow_down_blue_border arrow_down_blue_border_selected"></span>'
+  );
+  $(element).addClass('scb_s_assignments_header_btn_selected');
   $('.scb_s_display_section').hide()
   $('.scb_s_display_section[value="' + section + '"]').show();
-  $('.arrow-down-blue').css('left',
-    ($('.arrow-down-blue').parent().width() / scb.ui.static.AssignmentsView.ARROW_DIVISION) - scb.ui.static.AssignmentsView.ARROW_OFFSET + 'px');
+  $('.arrow_down_blue_background', '.scb_s_assignments_view').css('left', scb.ui.static.AssignmentsView.BUTTON_LEFT - 4 + 'px');
+  $('.arrow_down_blue_border', '.scb_s_assignments_view').css('left', scb.ui.static.AssignmentsView.BUTTON_LEFT + 'px');
 
 
   if (element == first_element) {
-    $('.scb_s_assignment_header_img_right').removeClass('scb_s_assignment_header_img_right_inactive');
-    $('.scb_s_assignment_header_img_left').addClass('scb_s_assignment_header_img_left_inactive');
+    $('.scb_s_assignments_header_btn_right').removeClass('scb_s_assignments_header_btn_right_inactive');
+    $('.scb_s_assignments_header_btn_left').addClass('scb_s_assignments_header_btn_left_inactive');
   } else if (element == last_element) {
-    $('.scb_s_assignment_header_img_right').addClass('scb_s_assignment_header_img_right_inactive');
-    $('.scb_s_assignment_header_img_left').removeClass('scb_s_assignment_header_img_left_inactive');
+    $('.scb_s_assignments_header_btn_right').addClass('scb_s_assignments_header_btn_right_inactive');
+    $('.scb_s_assignments_header_btn_left').removeClass('scb_s_assignments_header_btn_left_inactive');
   } else {
-    $('.scb_s_assignment_header_img_right').removeClass('scb_s_assignment_header_img_right_inactive');
-    $('.scb_s_assignment_header_img_left').removeClass('scb_s_assignment_header_img_left_inactive');
+    $('.scb_s_assignments_header_btn_right').removeClass('scb_s_assignments_header_btn_right_inactive');
+    $('.scb_s_assignments_header_btn_left').removeClass('scb_s_assignments_header_btn_left_inactive');
   }
-  parsed.assignment.last_instruction = $('.scb_assignments_header_link_selected').index() - 1;
+  parsed.assignment.last_instruction = $('.scb_s_assignments_header_btn_selected').index() - 1;
   console.log(parsed.assignment.last_instruction);
 
   var assignment_window = $('.scb_s_assignment_scroll', '.scb_s_assignments_view').get(0);
@@ -70,37 +72,41 @@ scb.ui.static.AssignmentsView.scb_assignments_header_link_wrapper = function(ele
 }
 
 
-scb.ui.static.AssignmentsView.scb_s_assignment_header_img_left = function(element, workarea) {
+scb.ui.static.AssignmentsView.scb_s_assignments_header_btn_left = function(element, workarea) {
 
 
   var parsed = scb.ui.static.AssignmentsView.parse(element);
   $('.scb_s_assignment_scroll', '.scb_s_assignments_view').scrollTop(0);
   var first_element = $('.scb_s_assignments_slider_header', '.scb_s_assignments_view').children().first().next().get(0);
   var selected_element;
-  if ($('.scb_assignments_header_link_selected', '.scb_s_assignments_view').get(0) == first_element || $('.scb_assignments_header_link_selected', '.scb_s_assignments_view').get(0) == $(first_element, '.scb_s_assignments_view').next().get(0)) {
+  if ($('.scb_s_assignments_header_btn_selected', '.scb_s_assignments_view').get(0) == first_element || $('.scb_s_assignments_header_btn_selected', '.scb_s_assignments_view').get(0) == $(first_element, '.scb_s_assignments_view').next().get(0)) {
     selected_element = first_element;
 
-    $('.scb_s_assignment_header_img_right').removeClass('scb_s_assignment_header_img_right_inactive');
-    $('.scb_s_assignment_header_img_left').addClass('scb_s_assignment_header_img_left_inactive');
+    $('.scb_s_assignments_header_btn_right').removeClass('scb_s_assignments_header_btn_right_inactive');
+    $('.scb_s_assignments_header_btn_left').addClass('scb_s_assignments_header_btn_left_inactive');
   } else {
-    selected_element = $('.scb_assignments_header_link_wrapper')[$('.scb_assignments_header_link_selected').index() - 1 - 1];
-    $('.scb_s_assignment_header_img_right').removeClass('scb_s_assignment_header_img_right_inactive');
-    $('.scb_s_assignment_header_img_left').removeClass('scb_s_assignment_header_img_left_inactive');
+    selected_element = $('.scb_s_assignments_header_btn')[$('.scb_s_assignments_header_btn_selected').index() - 1 - 1];
+    $('.scb_s_assignments_header_btn_right').removeClass('scb_s_assignments_header_btn_right_inactive');
+    $('.scb_s_assignments_header_btn_left').removeClass('scb_s_assignments_header_btn_left_inactive');
   }
 
-  $('.scb_assignments_header_link_wrapper').removeClass('scb_assignments_header_link_selected');
-  $(selected_element).addClass('scb_assignments_header_link_selected');
+  $('.scb_s_assignments_header_btn').removeClass('scb_s_assignments_header_btn_selected');
+  $(selected_element).addClass('scb_s_assignments_header_btn_selected');
 
-  $('.arrow-down-blue').detach();
-  $(selected_element).append('<div class="arrow-down-blue"></div>');
+  $('.arrow_down_blue_background, .arrow_down_blue_border').detach();
+  $(selected_element).append(
+    '<span class="arrow_down_blue_background"></span>',
+    '<span class="arrow_down_blue_border arrow_down_blue_border_selected"></span>'
+  );
   var section = $(selected_element).attr('value');
-  $('.arrow-down-blue').css('left', ($('.arrow-down-blue').parent().width() / scb.ui.static.AssignmentsView.ARROW_DIVISION) - scb.ui.static.AssignmentsView.ARROW_OFFSET + 'px');
+  $('.arrow_down_blue_background', '.scb_s_assignments_view').css('left', scb.ui.static.AssignmentsView.BUTTON_LEFT - 4 + 'px');
+  $('.arrow_down_blue_border', '.scb_s_assignments_view').css('left', scb.ui.static.AssignmentsView.BUTTON_LEFT + 'px');
 
 
   $('.scb_s_display_section').hide()
   $('.scb_s_display_section[value="' + section + '"]').show();
 
-  parsed.assignment.last_instruction = $('.scb_assignments_header_link_selected').index() - 1 - 1;
+  parsed.assignment.last_instruction = $('.scb_s_assignments_header_btn_selected').index() - 1 - 1;
   console.log(parsed.assignment.last_instruction);
 
   var assignment_window = $('.scb_s_assignment_scroll', '.scb_s_assignments_view').get(0);
@@ -113,35 +119,39 @@ scb.ui.static.AssignmentsView.scb_s_assignment_header_img_left = function(elemen
 }
 
 
-scb.ui.static.AssignmentsView.scb_s_assignment_header_img_right = function(element, workarea) {
+scb.ui.static.AssignmentsView.scb_s_assignments_header_btn_right = function(element, workarea) {
   var parsed = scb.ui.static.AssignmentsView.parse(element);
   $('.scb_s_assignment_scroll', '.scb_s_assignments_view').scrollTop(0);
   var last_element = $('.scb_s_assignments_slider_header', '.scb_s_assignments_view').children().last().prev().get(0);
   var selected_element;
-  if ($('.scb_assignments_header_link_selected', '.scb_s_assignments_view').get(0) == last_element || $('.scb_assignments_header_link_selected', '.scb_s_assignments_view').get(0) == $(last_element, '.scb_s_assignments_view').prev().get(0)) {
+  if ($('.scb_s_assignments_header_btn_selected', '.scb_s_assignments_view').get(0) == last_element || $('.scb_s_assignments_header_btn_selected', '.scb_s_assignments_view').get(0) == $(last_element, '.scb_s_assignments_view').prev().get(0)) {
     selected_element = last_element;
-    $('.scb_s_assignment_header_img_right').addClass('scb_s_assignment_header_img_right_inactive');
-    $('.scb_s_assignment_header_img_left').removeClass('scb_s_assignment_header_img_left_inactive');
+    $('.scb_s_assignments_header_btn_right').addClass('scb_s_assignments_header_btn_right_inactive');
+    $('.scb_s_assignments_header_btn_left').removeClass('scb_s_assignments_header_btn_left_inactive');
   } else {
-    selected_element = $('.scb_assignments_header_link_wrapper')[$('.scb_assignments_header_link_selected').index()];
+    selected_element = $('.scb_s_assignments_header_btn')[$('.scb_s_assignments_header_btn_selected').index()];
 
-    $('.scb_s_assignment_header_img_right').removeClass('scb_s_assignment_header_img_right_inactive');
-    $('.scb_s_assignment_header_img_left').removeClass('scb_s_assignment_header_img_left_inactive');
+    $('.scb_s_assignments_header_btn_right').removeClass('scb_s_assignments_header_btn_right_inactive');
+    $('.scb_s_assignments_header_btn_left').removeClass('scb_s_assignments_header_btn_left_inactive');
   }
-  $('.scb_assignments_header_link_wrapper').removeClass('scb_assignments_header_link_selected');
-  $(selected_element).addClass('scb_assignments_header_link_selected');
+  $('.scb_s_assignments_header_btn').removeClass('scb_s_assignments_header_btn_selected');
+  $(selected_element).addClass('scb_s_assignments_header_btn_selected');
 
 
-  $('.arrow-down-blue').detach();
-  $(selected_element).append('<div class="arrow-down-blue"></div>');
+  $('.arrow_down_blue_background, .arrow_down_blue_border').detach();
+  $(selected_element).append(
+    '<span class="arrow_down_blue_background"></span>',
+    '<span class="arrow_down_blue_border arrow_down_blue_border_selected"></span>'
+  );
   var section = $(selected_element).attr('value');
-  $('.arrow-down-blue').css('left', ($('.arrow-down-blue').parent().width() / scb.ui.static.AssignmentsView.ARROW_DIVISION) - scb.ui.static.AssignmentsView.ARROW_OFFSET + 'px');
+  $('.arrow_down_blue_background', '.scb_s_assignments_view').css('left', scb.ui.static.AssignmentsView.BUTTON_LEFT - 4 + 'px');
+  $('.arrow_down_blue_border', '.scb_s_assignments_view').css('left', scb.ui.static.AssignmentsView.BUTTON_LEFT + 'px');
 
 
   $('.scb_s_display_section').hide()
   $('.scb_s_display_section[value="' + section + '"]').show();
 
-  parsed.assignment.last_instruction = $('.scb_assignments_header_link_selected').index() - 1;
+  parsed.assignment.last_instruction = $('.scb_s_assignments_header_btn_selected').index() - 1;
   console.log(parsed.assignment.last_instruction);
   var assignment_window = $('.scb_s_assignment_scroll').get(0);
   if (assignment_window.scrollHeight == assignment_window.clientHeight) {
@@ -153,19 +163,19 @@ scb.ui.static.AssignmentsView.scb_s_assignment_header_img_right = function(eleme
 }
 
 scb.ui.static.AssignmentsView.register = function(workarea) {
-  scb.utils.off_on(workarea, 'click', '.scb_assignments_header_link_wrapper', function(e) {
-    scb.ui.static.AssignmentsView.scb_assignments_header_link_wrapper(this, e);
+  scb.utils.off_on(workarea, 'click mousedown', '.scb_s_assignments_header_btn', function(e) {
+    scb.ui.static.AssignmentsView.scb_s_assignments_header_btn(this, e);
   });
 
-  scb.utils.off_on(workarea, 'click', '.scb_s_assignment_header_img_left', function(e) {
-    if (!$(this).hasClass('scb_s_assignment_header_img_left_inactive')) {
-      scb.ui.static.AssignmentsView.scb_s_assignment_header_img_left(this, e);
+  scb.utils.off_on(workarea, 'click', '.scb_s_assignments_header_btn_left', function(e) {
+    if (!$(this).hasClass('scb_s_assignments_header_btn_left_inactive')) {
+      scb.ui.static.AssignmentsView.scb_s_assignments_header_btn_left(this, e);
     }
   });
 
-  scb.utils.off_on(workarea, 'click', '.scb_s_assignment_header_img_right', function(e) {
-    if (!$(this).hasClass('scb_s_assignment_header_img_right_inactive')) {
-      scb.ui.static.AssignmentsView.scb_s_assignment_header_img_right(this, e);
+  scb.utils.off_on(workarea, 'click', '.scb_s_assignments_header_btn_right', function(e) {
+    if (!$(this).hasClass('scb_s_assignments_header_btn_right_inactive')) {
+      scb.ui.static.AssignmentsView.scb_s_assignments_header_btn_right(this, e);
     }
   });
   scb.utils.off_on(workarea, 'click', '.scb_assignments_new_experiment', function(e) {
@@ -224,13 +234,15 @@ scb.ui.AssignmentsView = function scb_ui_AssignmentsView(gstate) {
     }));
 
     scb.ui.static.HomepageView.select_list_item($('.scb_s_homepage_experimental_design_bullet_item', workarea).first(), gstate.workarea);
-    document.title = "Assignments - StarCellBio"
-    $('.scb_assignments_header_link_wrapper', '.scb_s_assignments_view').css('width',
-      (scb.ui.static.AssignmentsView.HEADER_WIDTH / assignments.selected.template.instructions.length) - scb.ui.static.AssignmentsView.HEADER_OFFSET + 'px');
-    $('.arrow-down-blue', '.scb_s_assignments_view').css('left', ($('.arrow-down-blue', '.scb_s_assignments_view').parent().width() / scb.ui.static.AssignmentsView.ARROW_DIVISION) - scb.ui.static.AssignmentsView.ARROW_OFFSET + 'px');
-
+    document.title = "Assignments - StarCellBio";
+    var prev_next_width = 2*40; // Total width of previous and next buttons
+    scb.ui.static.AssignmentsView.BUTTON_WIDTH = (scb.ui.static.AssignmentsView.HEADER_WIDTH - prev_next_width) / assignments.selected.template.instructions.length;
+    scb.ui.static.AssignmentsView.BUTTON_LEFT = (scb.ui.static.AssignmentsView.BUTTON_WIDTH/2) - 14;
+    $('.scb_s_assignments_header_btn', '.scb_s_assignments_view').css('width', scb.ui.static.AssignmentsView.BUTTON_WIDTH + 'px');
+    $('.arrow_down_blue_background', '.scb_s_assignments_view').css('left', scb.ui.static.AssignmentsView.BUTTON_LEFT - 4 + 'px');
+    $('.arrow_down_blue_border', '.scb_s_assignments_view').css('left', scb.ui.static.AssignmentsView.BUTTON_LEFT + 'px');
     $('.scb_s_ref_info_link').click(function() {
-      $('.scb_assignments_header_link_wrapper[value="Reference Material"]').click();
+      $('.scb_s_assignments_header_btn[value="Reference Material"]').click();
     });
     var assignment_window = $('.scb_s_assignment_scroll', '.scb_s_assignments_view').get(0);
     if (assignment_window.scrollHeight == assignment_window.clientHeight) {

--- a/html_app/ui/ExperimentSetupView.js
+++ b/html_app/ui/ExperimentSetupView.js
@@ -185,6 +185,16 @@ scb.ui.static.ExperimentSetupView.register = function(workarea) {
   scb.utils.off_on(workarea, 'click', '.scb_f_open_experiment_setup_readonly', function(e) {
     scb.ui.static.ExperimentSetupView.scb_f_open_experiment_setup_readonly(this, e);
   });
+  /*
+    jqDialog adds a keyup event handler to the document element that we do not want to be called
+    when the [Run Experiment] link has focus and the ENTER key is used.
+    When this happens, the click event is triggered as well as the keyup event and its bubbling
+    cannot be cancelled with event.stopPropagation(). We remove all keyup event handlers on the
+    document instead.
+  */
+  scb.utils.off_on(workarea, 'keydown', '.scb_f_open_experiment_setup_readonly', function() {
+    $(document).off();
+  });
 
   scb.utils.off_on(workarea, 'click', '.scb_f_experiment_setup_action_open_add_samples_dialog', function(e) {
     $(workarea).prepend(scb_common.contact_overlay());
@@ -297,7 +307,6 @@ scb.ui.static.ExperimentSetupView.scb_f_open_experiment_setup_readonly = functio
     } else {
       $('body').prepend(scb_experiment_setup.experiment_setup_overlay());
       $(element).attr('href', 'javascript:void(0)');
-      $('#jqDialog_box').css('width', '570px');
       $.jqDialog.content(scb_experiment_setup.experiment_setup_dialog({
         assignment: parsed.assignment,
         experiment: parsed.experiment
@@ -311,6 +320,7 @@ scb.ui.static.ExperimentSetupView.scb_f_open_experiment_setup_readonly = functio
           $('#jqDialog_box').hide();
         }
       });
+      $('.scb_f_open_experiment_setup').focus();
       $('.scb_f_open_select_technique').click(function() {
         if ($('.scb_s_warning_dialog').length > 0) {
           $('.scb_s_warning_dialog').remove();
@@ -321,7 +331,8 @@ scb.ui.static.ExperimentSetupView.scb_f_open_experiment_setup_readonly = functio
       });
 
     }
-
+    // Center dialog window
+    $.jqDialog.makeCenter($('#jqDialog_box'));
   }
 }
 

--- a/html_app/ui/FacsView.js
+++ b/html_app/ui/FacsView.js
@@ -667,6 +667,17 @@ scb.ui.static.FacsView.register = function(workarea) {
   });
   scb.utils.off_on(workarea, 'click', '.scb_f_facs_prepare_lysates', function(e) {
     scb.ui.static.FacsView.scb_f_facs_prepare_lysates(this, e);
+    event.preventDefault();
+  });
+  /*
+    jqDialog adds a keyup event handler to the document element that we do not want to be called
+    when the [Prepare Samples] link has focus and the ENTER key is used.
+    When this happens, the click event is triggered as well as the keyup event and its bubbling
+    cannot be cancelled with event.stopPropagation(). We remove all keyup event handlers on the
+    document instead.
+  */
+  scb.utils.off_on(workarea, 'keydown', '.scb_f_facs_prepare_lysates', function() {
+    $(document).off();
   });
   scb.utils.off_on(workarea, 'click', '.scb_s_facs_single_range_button', function(e) {
     scb.ui.static.FacsView.scb_s_facs_single_range_button(this, e);

--- a/html_app/ui/HomepageView.js
+++ b/html_app/ui/HomepageView.js
@@ -23,12 +23,10 @@ scb.ui.static.HomepageView.select_list_item = function(element, workarea, aria) 
   }
 }
 
-
 scb.ui.static.HomepageView.register = function(workarea) {
   scb.utils.off_on(workarea, 'click', '.scb_s_homepage_experimental_design_bullet_item', function(e) {
     scb.ui.static.HomepageView.select_list_item(this, workarea, true);
   });
-
 
   scb.utils.off_on(workarea, 'click', '.learn_more_dynamic', function(e) {
     var pop_string = $(this).attr('value');
@@ -38,7 +36,6 @@ scb.ui.static.HomepageView.register = function(workarea) {
   });
 
   scb.utils.off_on(workarea, 'click', '.scb_f_create_student_account', function(e) {
-
     $(workarea).append(scb_auth.signup({}));
     scb.utils.off_on(workarea, 'click', '.scb_f_signup_close_button', function() {
       $('.scb_s_signup_dialog').detach();
@@ -96,28 +93,22 @@ scb.ui.static.HomepageView.register = function(workarea) {
             if ($('.scb_f_signup_iframe').contents().find('.login_submit').length > 0) {
               $('.scb_f_signup_iframe').contents().find('#errorMsg').html('Incorrect username or password. Try again');
             }
-
           }
         });
       });
     });
-
   });
-
-
 
   scb.utils.off_on(workarea, 'click', '.scb_s_homepage_see_more_button', function(e) {
     alert("under construction!");
   });
+
   scb.utils.off_on(workarea, 'click', '.scb_f_create_instructors_account', function(e) {
-
-
     $(workarea).append(scb_auth.signup({}));
     scb.utils.off_on(workarea, 'click', '.scb_f_signup_close_button', function() {
       $('.scb_s_signup_dialog').detach();
     });
     $('.scb_f_signup_iframe').load(function() {
-
       var iframe = $('.scb_f_signup_iframe').get(0);
       var content = (iframe.contentDocument || iframe.contentWindow);
       content.body.style.fontSize = '90%';
@@ -177,16 +168,11 @@ scb.ui.static.HomepageView.register = function(workarea) {
         });
       });
     });
-
-
   });
-
 
   scb.utils.off_on(workarea, 'click', '.scb_f_instructor_resources', function(e) {
     alert("under construction!");
   });
-
-
 };
 
 scb.ui.HomepageView = function scb_ui_HomepageView(gstate) {
@@ -211,10 +197,8 @@ scb.ui.HomepageView = function scb_ui_HomepageView(gstate) {
         left: ($(window).width() - $('#main').outerWidth()) / 2,
         top: ($(window).height() - $('#main').outerHeight()) / 2
       });
-
     });
   }
-
 }
 
 function inConstructionError() {

--- a/html_app/ui/HomepageView.js
+++ b/html_app/ui/HomepageView.js
@@ -24,6 +24,23 @@ scb.ui.static.HomepageView.select_list_item = function(element, workarea, aria) 
 }
 
 scb.ui.static.HomepageView.register = function(workarea) {
+  // Skip to content link
+  scb.utils.off_on(workarea, 'click', '.scb_s_skip_to_content', function(e) {
+    var hash = window.location.hash, params, view, content = '.scb_s_homepage_content';
+    if (hash !== '') {
+      params = hash.substr(1).split('&');
+      view = params[0].split('=')[1];
+      if (view !== 'homepage') {
+        content = '.scb_s_' + view + '_container';
+        if (view === 'facs') {
+          content += '_student';
+        }
+      }
+    }
+    $(content).find(':focusable').first().focus();
+    e.preventDefault();
+  });
+
   scb.utils.off_on(workarea, 'click', '.scb_s_homepage_experimental_design_bullet_item', function(e) {
     scb.ui.static.HomepageView.select_list_item(this, workarea, true);
   });

--- a/html_app/ui/MainFrame.js
+++ b/html_app/ui/MainFrame.js
@@ -400,11 +400,8 @@ scb.ui.MainFrame = function scb_ui_MainFrame(master_model, context) {
         }
       });
     });
-
+    $('.scb_f_ug_close_button').focus();
     $('iframe.scb_s_ug_dialog').load(function() {
-      $('.scb_f_ug_help_search_bar').width($('iframe.scb_s_ug_dialog').contents().find('.scb_f_help_display').width() + 20);
-      $('iframe.scb_s_ug_dialog').width($('iframe.scb_s_ug_dialog').contents().find('.scb_f_help').width() + 20);
-      $('iframe.scb_s_ug_dialog').height($('iframe.scb_s_ug_dialog').contents().find('.scb_f_help').height() + 20);
       $('.scb_f_ug_help_search_bar').draggable({
         handle: '.user_guide_title'
       });

--- a/html_app/ui/MicroscopyView.js
+++ b/html_app/ui/MicroscopyView.js
@@ -1729,6 +1729,17 @@ scb.ui.static.MicroscopyView.register = function(workarea) {
   });
   scb.utils.off_on(workarea, 'click', '.scb_f_microscopy_prepare_slides', function(e) {
     scb.ui.static.MicroscopyView.scb_f_microscopy_prepare_slides(this);
+    e.preventDefault();
+  });
+  /*
+    jqDialog adds a keyup event handler to the document element that we do not want to be called
+    when the [Prepare Slides] link has focus and the ENTER key is used.
+    When this happens, the click event is triggered as well as the keyup event and its bubbling
+    cannot be cancelled with event.stopPropagation(). We remove all keyup event handlers on the
+    document instead.
+  */
+  scb.utils.off_on(workarea, 'keydown', '.scb_f_microscopy_prepare_slides', function() {
+    $(document).off();
   });
   scb.utils.off_on(workarea, 'click', '.scb_f_microscopy_sample_active_all', function(e, ui) {
     scb.ui.static.MicroscopyView.scb_f_microscopy_sample_active_all(this);

--- a/html_app/ui/WesternBlotView.js
+++ b/html_app/ui/WesternBlotView.js
@@ -485,6 +485,17 @@ scb.ui.static.WesternBlotView.register = function(workarea) {
   });
   scb.utils.off_on(workarea, 'click', '.scb_f_western_blot_prepare_lysates', function(e) {
     scb.ui.static.WesternBlotView.scb_f_western_blot_prepare_lysates(this);
+    e.preventDefault();
+  });
+  /*
+    jqDialog adds a keyup event handler to the document element that we do not want to be called
+    when the [Prepare Lysates] link has focus and the ENTER key is used.
+    When this happens, the click event is triggered as well as the keyup event and its bubbling
+    cannot be cancelled with event.stopPropagation(). We remove all keyup event handlers on the
+    document instead.
+  */
+  scb.utils.off_on(workarea, 'keydown', '.scb_f_western_blot_prepare_lysates', function() {
+    $(document).off();
   });
   scb.utils.off_on(workarea, 'click', '.scb_s_western_blot_load_marker', function(e) {
     scb.ui.static.WesternBlotView.scb_s_western_blot_load_marker(this);

--- a/html_app/ui/assignments.gss
+++ b/html_app/ui/assignments.gss
@@ -5,16 +5,19 @@
   /* @alternate */ background-image: -ms-linear-gradient(POS, START_COLOR, END_COLOR);  /* IE10 */
   /* @alternate */ background-image: -o-linear-gradient(POS, START_COLOR, END_COLOR);   /* Opera 11.10+ */
 }
+
 .scb_s_assignments_view {
     width: 1002px;
     background-color: #f4f6f8;
 }
-.scb_s_assignments_container{
-	background: white;
-	padding-bottom: 51px;
-	position: relative;
-	z-index: 1;
+
+.scb_s_assignments_container {
+    background: white;
+    padding-bottom: 51px;
+    position: relative;
+    z-index: 1;
 }
+
 .scb_s_abstract {
     margin-top: 22px;
     text-align: justify;
@@ -31,23 +34,22 @@
     margin-left: 11px;
 }
 
-
 .scb_s_assignments_description>.scb_f_open_experiment {
     bottom: 5px;
     float:right;
     margin-top: 25px;
 }
 
-.scb_s_assignments_slider_header{
-	display: inline-block;
-	max-height: 40px;
-	position: absolute;
-	z-index: 999;
-	background-image: linear-gradient(to bottom, #ccc, #f5f5f5 18px, #ccc 36px);;
+.scb_s_assignments_slider_header {
+    display: inline-block;
+    max-height: 40px;
+    position: absolute;
+    z-index: 999;
+    background-image: linear-gradient(to bottom, #ccc, #f5f5f5 18px, #ccc 36px);;
 }
 
-.scb_s_assignments_slider_header > div{
-	display: inline-block;
+.scb_s_assignments_slider_header > div {
+    display: inline-block;
 }
 
 /*
@@ -57,224 +59,215 @@
 */
 
 .scb_s_assignments_header_btn_left {
-	position: relative;
-	margin-left: -10px;
-	cursor: pointer;
-	width: 40px;
-	height: 40px;
-	outline: none;
-	border: none;
-	background: url('../../images/western_blot/scb_gray_left_arrow_active.png') center center / cover no-repeat;
+    position: relative;
+    margin-left: -10px;
+    cursor: pointer;
+    width: 40px;
+    height: 40px;
+    outline: none;
+    border: none;
+    background: url('../../images/western_blot/scb_gray_left_arrow_active.png') center center / cover no-repeat;
 }
 
 .scb_s_assignments_header_btn_left:focus {
-	outline: 2px solid black;
-	outline-offset: -2px;
+    outline: 2px solid black;
+    outline-offset: -2px;
 }
 
 .scb_s_assignments_header_btn_left:hover:not(.scb_s_assignments_header_btn_left_inactive) {
-	background: url('../../images/western_blot/scb_gray_left_arrow_hover.png') center center / cover no-repeat;
+    background: url('../../images/western_blot/scb_gray_left_arrow_hover.png') center center / cover no-repeat;
 }
 
 .scb_s_assignments_header_btn_left_inactive {
-	background: url('../../images/western_blot/scb_gray_left_arrow_inactive.png') center center / cover no-repeat;
+    background: url('../../images/western_blot/scb_gray_left_arrow_inactive.png') center center / cover no-repeat;
 }
 
 .scb_s_assignments_header_btn_right {
-	position: relative;
-	margin-right: -10px;
-	cursor: pointer;
-	width: 40px;
-	height: 40px;
-	outline: none;
-	border: none;
-	background: url('../../images/western_blot/scb_gray_right_arrow_active.png') center center / cover no-repeat;
+    position: relative;
+    margin-right: -10px;
+    cursor: pointer;
+    width: 40px;
+    height: 40px;
+    outline: none;
+    border: none;
+    background: url('../../images/western_blot/scb_gray_right_arrow_active.png') center center / cover no-repeat;
 }
 
 .scb_s_assignments_header_btn_right:focus {
-	outline: 2px solid black;
-	outline-offset: -2px;
+    outline: 2px solid black;
+    outline-offset: -2px;
 }
 
 .scb_s_assignments_header_btn_right:hover:not(.scb_s_assignments_header_btn_right_inactive) {
-	background: url('../../images/western_blot/scb_gray_right_arrow_hover.png') center center / cover no-repeat;
+    background: url('../../images/western_blot/scb_gray_right_arrow_hover.png') center center / cover no-repeat;
 }
 
 .scb_s_assignments_header_btn_right_inactive {
-	background: url('../../images/western_blot/scb_gray_right_arrow_inactive.png') center center / cover no-repeat;
+    background: url('../../images/western_blot/scb_gray_right_arrow_inactive.png') center center / cover no-repeat;
 }
 
 .scb_s_assignments_header_btn {
-	/* Color lightened by 20% from top to center then darkened by 20% from center to bottom*/
-	background-image: linear-gradient(to bottom, #ccc, #ffffff 18px, #ccc 36px);
-	outline: none;
-	border: 2px solid transparent;
-	position: relative;
-	width: 150px;
-	height: 40px;
-	cursor: pointer;
-	color: #316f94;
-	font-size: 11pt;
-	font-family: 'sourcesanspro-semibold';
-	vertical-align: top;
+    /* Color lightened by 20% from top to center then darkened by 20% from center to bottom*/
+    background-image: linear-gradient(to bottom, #ccc, #ffffff 18px, #ccc 36px);
+    outline: none;
+    border: 2px solid transparent;
+    position: relative;
+    width: 150px;
+    height: 40px;
+    cursor: pointer;
+    color: #316f94;
+    font-size: 11pt;
+    font-family: 'sourcesanspro-semibold';
+    vertical-align: top;
 }
 
 .scb_s_assignments_header_btn > .arrow_down_blue_background {
-	position: absolute;
-	width: 0;
-	height: 0;
-	top: 36px;
-	border-left: 15px solid transparent;
-	border-right: 15px solid transparent;
-	border-top: 15px solid #4690c1;
+    position: absolute;
+    width: 0;
+    height: 0;
+    top: 36px;
+    border-left: 15px solid transparent;
+    border-right: 15px solid transparent;
+    border-top: 15px solid #4690c1;
 }
 
 .scb_s_assignments_header_btn > .arrow_down_blue_border {
-	position: absolute;
-	width: 20px;
-	height: 20px;
-	top: 27px;
-	background: transparent;
-	transform: rotate(45deg);
-	border: none;
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 27px;
+    background: transparent;
+    transform: rotate(45deg);
+    border: none;
 }
 
 .scb_s_assignments_header_btn:focus {
-	border: 2px solid black;
+    border: 2px solid black;
 }
 
 .scb_s_assignments_header_btn:focus > .arrow_down_blue_border_selected {
-	border-right: 2px solid black;
-	border-bottom: 2px solid black;
+    border-right: 2px solid black;
+    border-bottom: 2px solid black;
 }
 
 .scb_s_assignments_header_btn > span {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    display: block;
 }
 
 .scb_s_assignments_header_btn_selected {
-	/* Color lightened by 20% from top to center then darkened by 20% from center to bottom */
-	background-image: linear-gradient(to bottom, #4690c1, #60aadb 18px, #4690c1 36px);
-	color: white;
+    /* Color lightened by 20% from top to center then darkened by 20% from center to bottom */
+    background-image: linear-gradient(to bottom, #4690c1, #60aadb 18px, #4690c1 36px);
+    color: white;
 }
 
 .scb_assignments_bottom_btn_left {
-	border-top-left-radius: 5px;
-	border-bottom-left-radius: 5px;
-	border: 1px solid gray;
-	border-right: none;
+    border-top-left-radius: 5px;
+    border-bottom-left-radius: 5px;
+    border: 1px solid gray;
+    border-right: none;
 }
 
 .scb_assignments_bottom_btn_right {
-	border-top-right-radius: 5px;
-	border-bottom-right-radius: 5px;
-	border: 1px solid gray;
-	border-left: none;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+    border: 1px solid gray;
+    border-left: none;
 }
 
 /* KEEP IN CASE IT IS NEEDED IN OLD INSTRUCTOR APPLICATION */
-.scb_s_assignment_header_img_left{
-	position:relative;
-	margin-left: -10px;
-	cursor:pointer;
-	display:inline;	
-	width:39px;
-	height: 41px;
-	background-image: url('../../images/western_blot/scb_gray_left_arrow_active.png');
-
-	
+.scb_s_assignment_header_img_left {
+    position:relative;
+    margin-left: -10px;
+    cursor:pointer;
+    display:inline;
+    width:39px;
+    height: 41px;
+    background-image: url('../../images/western_blot/scb_gray_left_arrow_active.png');
 }
 
-.scb_s_assignment_header_img_right{
-	position:relative;
-	margin-right: -10px;
-	cursor: pointer;
-	display:inline;
-	width:39px;
-	height: 41px;
-	background-image: url('../../images/western_blot/scb_gray_right_arrow_active.png');
-
+.scb_s_assignment_header_img_right {
+    position:relative;
+    margin-right: -10px;
+    cursor: pointer;
+    display:inline;
+    width:39px;
+    height: 41px;
+    background-image: url('../../images/western_blot/scb_gray_right_arrow_active.png');
 }
 
-.scb_s_assignment_header_img_left_inactive{
-background-image: url('../../images/western_blot/scb_gray_left_arrow_inactive.png');
-
+.scb_s_assignment_header_img_left_inactive {
+    background-image: url('../../images/western_blot/scb_gray_left_arrow_inactive.png');
 }
 
-.scb_s_assignment_header_img_right_inactive{
-background-image:url('../../images/western_blot/scb_gray_right_arrow_inactive.png');
+.scb_s_assignment_header_img_right_inactive {
+    background-image:url('../../images/western_blot/scb_gray_right_arrow_inactive.png');
 }
 
-
-.scb_s_assignment_header_img_left:hover:not(.scb_s_assignment_header_img_left_inactive){
-background-image: url('../../images/western_blot/scb_gray_left_arrow_hover.png') !important;
-
+.scb_s_assignment_header_img_left:hover:not(.scb_s_assignment_header_img_left_inactive) {
+    background-image: url('../../images/western_blot/scb_gray_left_arrow_hover.png') !important;
 }
 
-.scb_s_assignment_header_img_right:hover:not(.scb_s_assignment_header_img_right_inactive){
-background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png') !important;
-
+.scb_s_assignment_header_img_right:hover:not(.scb_s_assignment_header_img_right_inactive) {
+    background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png') !important;
 }
 
-.scb_assignments_header_link_wrapper >span{
-
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	display:block;
-	overflow: hidden;
-}
-.scb_assignments_header_link_wrapper{
-	height: 16px;
-	background: rgba(0,0,0,0);
-	cursor: pointer;
-	color: #316f94;
-	vertical-align: top;
-	text-align: center;
-	font-size: 11pt;
-	font-family:'sourcesanspro-semibold';
-	padding: 12px 22px 13px 12px;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	box-shadow: inset 0px 16px 8px -10px #CCB, inset 0px -16px 8px -10px #CCC;
+.scb_assignments_header_link_wrapper > span {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    display:block;
+    overflow: hidden;
 }
 
-.scb_assignments_header_link_selected >span{
-	background: #4690C1;
-	
-	padding: 12px 22px 10px 12px;
-	right: 12px;
-	position: relative;
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	width: inherit;
-	display: block;
-	bottom: 12px;
-	box-shadow: inset 0 11px 36px -14px #000,inset 0 -25px 0px -38px #000;
+.scb_assignments_header_link_wrapper {
+    height: 16px;
+    background: rgba(0,0,0,0);
+    cursor: pointer;
+    color: #316f94;
+    vertical-align: top;
+    text-align: center;
+    font-size: 11pt;
+    font-family:'sourcesanspro-semibold';
+    padding: 12px 22px 13px 12px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    box-shadow: inset 0px 16px 8px -10px #CCB, inset 0px -16px 8px -10px #CCC;
 }
 
+.scb_assignments_header_link_selected > span {
+    background: #4690C1;
+    padding: 12px 22px 10px 12px;
+    right: 12px;
+    position: relative;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    width: inherit;
+    display: block;
+    bottom: 12px;
+    box-shadow: inset 0 11px 36px -14px #000,inset 0 -25px 0px -38px #000;
+}
 
-.arrow-down-blue{
-	width: 0;
-	height: 0;
-	border-left: 20px solid transparent;
-	border-right: 20px solid transparent;
-	border-top: 20px solid #4690C1;
-	top: -16px;
-	position: relative;
+.arrow-down-blue {
+    width: 0;
+    height: 0;
+    border-left: 20px solid transparent;
+    border-right: 20px solid transparent;
+    border-top: 20px solid #4690C1;
+    top: -16px;
+    position: relative;
 }
 /* END KEEP */
 
-.scb_s_display_section{
-	display:none;
-	font-size:11pt;
+.scb_s_display_section {
+    display:none;
+    font-size:11pt;
 }
 
-.scb_s_display_section[value='assignment_overview']{
-	display:block;
+.scb_s_display_section[value='assignment_overview'] {
+    display:block;
 }
 
 .scb_s_display_section li {
@@ -289,15 +282,14 @@ background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png')
     color: #676767;
 }
 
-.scb_assignments_header_link_selected{
-	color:white;
-	background-repeat:no-repeat;
-	background-size: 100% 100%;
+.scb_assignments_header_link_selected {
+    color:white;
+    background-repeat:no-repeat;
+    background-size: 100% 100%;
 }
 
-
-.scb_s_abstract_title_underline{
-	width: 664px;
+.scb_s_abstract_title_underline {
+    width: 664px;
 }
 
 .scb_s_abstract > h1 {
@@ -307,16 +299,16 @@ background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png')
 
 .scb_s_abstract_title {
     color: white;
-	background: #27956c;
-	font-size: 13pt;
-	padding: 12px 0 6px 17px;
-	font-family: 'sourcesanspro-semibold';
-	margin-top: -10px;
-	margin-left: -10px;
-	border-top-left-radius: inherit;
-	border-top-right-radius: inherit;
-	margin-right: -10px;
-	letter-spacing: 0.9px;
+    background: #27956c;
+    font-size: 13pt;
+    padding: 12px 0 6px 17px;
+    font-family: 'sourcesanspro-semibold';
+    margin-top: -10px;
+    margin-left: -10px;
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
+    margin-right: -10px;
+    letter-spacing: 0.9px;
 }
 
 .scb_s_assignments_sidebar_title {
@@ -324,11 +316,11 @@ background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png')
     padding: 11px 0px 6px 17px;
     font-family: "sourcesanspro-semibold";
     text-align: left;
-	border-top-left-radius: 8px;
-	border-top-right-radius: 8px;
-	color: white;
-	background: #27956c;
-	margin: -5px;
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+    color: white;
+    background: #27956c;
+    margin: -5px;
 }
 
 .assignments_block {
@@ -351,13 +343,13 @@ background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png')
     color:black;
 }
 
-.scb_f_open_assignment_experiment,.scb_f_new_assignment_experiment {
+.scb_f_open_assignment_experiment, .scb_f_new_assignment_experiment {
     text-decoration: none;
     color:black;
 }
 
 .assignement_column_wrapper {
-    padding-right: 400px;    
+    padding-right: 400px;
 }
 
 .assignments_description {
@@ -376,31 +368,28 @@ background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png')
     background-color: #f4f6f8;
     margin-left: 33px;
     border: 1px solid #d8eee7;
-	box-shadow: 0 0 0 0;
-	border-radius: 8px;
+    box-shadow: 0 0 0 0;
+    border-radius: 8px;
 }
 
 .scb_s_assignments_sidebar > ul {
     margin-left:-28px;
     list-style:none;
     margin-top: 22px;
-
 }
-
 
 .arrow-down {
-	width: 0; 
-	height: 0; 
-	border-left: 20px solid transparent;
-	border-right: 20px solid transparent;
-	border-top: 20px solid #27956c;
-	left: 121px;
-	position: absolute;
-	
+    width: 0;
+    height: 0;
+    border-left: 20px solid transparent;
+    border-right: 20px solid transparent;
+    border-top: 20px solid #27956c;
+    left: 121px;
+    position: absolute;
 }
 
-.scb_s_assignments_sidebar_name_selected{
-	background: #c9cdd0;
+.scb_s_assignments_sidebar_name_selected {
+    background: #c9cdd0;
 }
 
 .scb_s_assignments_sidebar_name {
@@ -408,62 +397,62 @@ background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png')
     margin-top: 3px;
     font-family: 'sourcesanspro-semibold';
     position: relative;
-	left: -18px;
-	width: 221px;
-	padding: 7px 3px 3px 33px;
-	height: 20px;
-	color: #010101;
+    left: -18px;
+    width: 221px;
+    padding: 7px 3px 3px 33px;
+    height: 20px;
+    color: #010101;
 }
+
 .assignement_assignement_description {
     font-size: 10px;
     margin-left:10px;
 }
 
-.scb_assignments_bottom_arrow_left{
-	border-top-left-radius: 5px;
-	border-bottom-left-radius: 5px;
-	border: 1px solid gray;
-	border-right: none;
-	display: inline-block !important;
+.scb_assignments_bottom_arrow_left {
+    border-top-left-radius: 5px;
+    border-bottom-left-radius: 5px;
+    border: 1px solid gray;
+    border-right: none;
+    display: inline-block !important;
 }
 
 
-.scb_assignments_bottom_arrow_right{
-	border-top-right-radius: 5px;
-	border-bottom-right-radius: 5px;
-	border: 1px solid gray;
-	border-left: none;
-	display: inline-block !important;
-
+.scb_assignments_bottom_arrow_right {
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+    border: 1px solid gray;
+    border-left: none;
+    display: inline-block !important;
 }
 
-.scb_s_assignments_gray_bar{
-	width: 657px;
-	height: 25px;
-	background: #f4f6f8;
-	position: absolute;
-	top: 81px;
-	left: 0;
+.scb_s_assignments_gray_bar {
+    width: 657px;
+    height: 25px;
+    background: #f4f6f8;
+    position: absolute;
+    top: 81px;
+    left: 0;
 }
 
-.scb_s_assignments_button_divider{
-	position: absolute;
-	display: inline;
-	width: 1px;
-	background: gray;
-	height: 41px;
-	z-index: 1;
+.scb_s_assignments_button_divider {
+    position: absolute;
+    display: inline;
+    width: 1px;
+    background: gray;
+    height: 41px;
+    z-index: 1;
 }
 
-.scb_s_assignments_print_assignment{
-	float:left !important;
-	background: none !important;
-	background-image: url('../../images/header/scb_print.png') !important;
+.scb_s_assignments_print_assignment {
+    float:left !important;
+    background: none !important;
+    background-image: url('../../images/header/scb_print.png') !important;
 }
 
-.scb_s_assignments_print_assignment:hover{
-	background-color: darkgray !important;
-	padding-right: 13px;
+.scb_s_assignments_print_assignment:hover {
+    background-color: darkgray !important;
+    padding-right: 13px;
 }
 
 .assignement_experiment_list {
@@ -479,6 +468,7 @@ background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png')
 .scb_s_assignment_experiment_list {
     list-style-type: disc;
 }
+
 .scb_s_abstract>.scb_f_select_assignment {
     position: absolute;
     bottom: 5px;
@@ -488,6 +478,7 @@ background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png')
 ul > .scb_s_assignment_experiment_list_item_new_experiment {
     padding-top: 10px;
 }
+
 .scb_s_assignment_experiment_list_item_new_experiment {
     padding-left:25px;
     font-family: 'sourcesanspro-bold';
@@ -496,23 +487,25 @@ ul > .scb_s_assignment_experiment_list_item_new_experiment {
 .scb_s_new_assignment_experiment {
     padding-left:9px;
 }
-.scb_s_assignments_bottom_scroll{
-	position:relative;
-	display:inline-block;
-	left: 277px;
+
+.scb_s_assignments_bottom_scroll {
+    position:relative;
+    display:inline-block;
+    left: 277px;
 }
-.scb_s_assignments_bottom_scroll_abs{
-	position: absolute !important;
-	top: 556px !important;
-	left: 293px !important;
+
+.scb_s_assignments_bottom_scroll_abs {
+    position: absolute !important;
+    top: 556px !important;
+    left: 293px !important;
 }
 
 .scb_s_assignments_sidebar_course {
     font-size:14pt;
     font-weight: bold;
     font-family: 'sourcesanspro-semibold';
-	color: #316f94;
-	text-transform: capitalize;
+    color: #316f94;
+    text-transform: capitalize;
 }
 
 .scb_s_assignments_sidebar_course_block {

--- a/html_app/ui/assignments.gss
+++ b/html_app/ui/assignments.gss
@@ -163,18 +163,21 @@
     color: white;
 }
 
-.scb_assignments_bottom_btn_left {
+.scb_s_assignments_bottom_btn_left {
     border-top-left-radius: 5px;
     border-bottom-left-radius: 5px;
     border: 1px solid gray;
     border-right: none;
 }
 
-.scb_assignments_bottom_btn_right {
+.scb_s_assignments_bottom_btn_left:focus + .scb_s_assignments_bottom_btn_right {
+    border-left: none;
+}
+
+.scb_s_assignments_bottom_btn_right {
     border-top-right-radius: 5px;
     border-bottom-right-radius: 5px;
     border: 1px solid gray;
-    border-left: none;
 }
 
 /* KEEP IN CASE IT IS NEEDED IN OLD INSTRUCTOR APPLICATION */
@@ -440,7 +443,7 @@
     display: inline;
     width: 1px;
     background: gray;
-    height: 41px;
+    height: 40px;
     z-index: 1;
 }
 

--- a/html_app/ui/assignments.gss
+++ b/html_app/ui/assignments.gss
@@ -43,14 +43,139 @@
 	max-height: 40px;
 	position: absolute;
 	z-index: 999;
-	background: rgba(0,0,0,0);
+	background-image: linear-gradient(to bottom, #ccc, #f5f5f5 18px, #ccc 36px);;
 }
-
 
 .scb_s_assignments_slider_header > div{
 	display: inline-block;
 }
 
+/*
+  To bypass Firefox outline bug: https://ctidd.com/2017/firefox-outline-bug
+  we use borders instead of outlines to display focus on buttons that display
+  a blue triangle when active.
+*/
+
+.scb_s_assignments_header_btn_left {
+	position: relative;
+	margin-left: -10px;
+	cursor: pointer;
+	width: 40px;
+	height: 40px;
+	outline: none;
+	border: none;
+	background: url('../../images/western_blot/scb_gray_left_arrow_active.png') center center / cover no-repeat;
+}
+
+.scb_s_assignments_header_btn_left:focus {
+	outline: 2px solid black;
+	outline-offset: -2px;
+}
+
+.scb_s_assignments_header_btn_left:hover:not(.scb_s_assignments_header_btn_left_inactive) {
+	background: url('../../images/western_blot/scb_gray_left_arrow_hover.png') center center / cover no-repeat;
+}
+
+.scb_s_assignments_header_btn_left_inactive {
+	background: url('../../images/western_blot/scb_gray_left_arrow_inactive.png') center center / cover no-repeat;
+}
+
+.scb_s_assignments_header_btn_right {
+	position: relative;
+	margin-right: -10px;
+	cursor: pointer;
+	width: 40px;
+	height: 40px;
+	outline: none;
+	border: none;
+	background: url('../../images/western_blot/scb_gray_right_arrow_active.png') center center / cover no-repeat;
+}
+
+.scb_s_assignments_header_btn_right:focus {
+	outline: 2px solid black;
+	outline-offset: -2px;
+}
+
+.scb_s_assignments_header_btn_right:hover:not(.scb_s_assignments_header_btn_right_inactive) {
+	background: url('../../images/western_blot/scb_gray_right_arrow_hover.png') center center / cover no-repeat;
+}
+
+.scb_s_assignments_header_btn_right_inactive {
+	background: url('../../images/western_blot/scb_gray_right_arrow_inactive.png') center center / cover no-repeat;
+}
+
+.scb_s_assignments_header_btn {
+	/* Color lightened by 20% from top to center then darkened by 20% from center to bottom*/
+	background-image: linear-gradient(to bottom, #ccc, #ffffff 18px, #ccc 36px);
+	outline: none;
+	border: 2px solid transparent;
+	position: relative;
+	width: 150px;
+	height: 40px;
+	cursor: pointer;
+	color: #316f94;
+	font-size: 11pt;
+	font-family: 'sourcesanspro-semibold';
+	vertical-align: top;
+}
+
+.scb_s_assignments_header_btn > .arrow_down_blue_background {
+	position: absolute;
+	width: 0;
+	height: 0;
+	top: 36px;
+	border-left: 15px solid transparent;
+	border-right: 15px solid transparent;
+	border-top: 15px solid #4690c1;
+}
+
+.scb_s_assignments_header_btn > .arrow_down_blue_border {
+	position: absolute;
+	width: 20px;
+	height: 20px;
+	top: 27px;
+	background: transparent;
+	transform: rotate(45deg);
+	border: none;
+}
+
+.scb_s_assignments_header_btn:focus {
+	border: 2px solid black;
+}
+
+.scb_s_assignments_header_btn:focus > .arrow_down_blue_border_selected {
+	border-right: 2px solid black;
+	border-bottom: 2px solid black;
+}
+
+.scb_s_assignments_header_btn > span {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	display: block;
+}
+
+.scb_s_assignments_header_btn_selected {
+	/* Color lightened by 20% from top to center then darkened by 20% from center to bottom */
+	background-image: linear-gradient(to bottom, #4690c1, #60aadb 18px, #4690c1 36px);
+	color: white;
+}
+
+.scb_assignments_bottom_btn_left {
+	border-top-left-radius: 5px;
+	border-bottom-left-radius: 5px;
+	border: 1px solid gray;
+	border-right: none;
+}
+
+.scb_assignments_bottom_btn_right {
+	border-top-right-radius: 5px;
+	border-bottom-right-radius: 5px;
+	border: 1px solid gray;
+	border-left: none;
+}
+
+/* KEEP IN CASE IT IS NEEDED IN OLD INSTRUCTOR APPLICATION */
 .scb_s_assignment_header_img_left{
 	position:relative;
 	margin-left: -10px;
@@ -141,6 +266,7 @@ background-image:url('../../images/western_blot/scb_gray_right_arrow_hover.png')
 	top: -16px;
 	position: relative;
 }
+/* END KEEP */
 
 .scb_s_display_section{
 	display:none;

--- a/html_app/ui/assignments.gss
+++ b/html_app/ui/assignments.gss
@@ -70,8 +70,9 @@
 }
 
 .scb_s_assignments_header_btn_left:focus {
-    outline: 2px solid black;
+    outline: 2px solid #1c1c1c;
     outline-offset: -2px;
+    box-shadow: none; /* Disables default focus indicator */
 }
 
 .scb_s_assignments_header_btn_left:hover:not(.scb_s_assignments_header_btn_left_inactive) {
@@ -94,8 +95,9 @@
 }
 
 .scb_s_assignments_header_btn_right:focus {
-    outline: 2px solid black;
+    outline: 2px solid #1c1c1c;
     outline-offset: -2px;
+    box-shadow: none; /* Disables default focus indicator */
 }
 
 .scb_s_assignments_header_btn_right:hover:not(.scb_s_assignments_header_btn_right_inactive) {
@@ -142,12 +144,13 @@
 }
 
 .scb_s_assignments_header_btn:focus {
-    border: 2px solid black;
+    border: 2px solid #1c1c1c;
+    box-shadow: none; /* Disables default focus indicator */
 }
 
 .scb_s_assignments_header_btn:focus > .arrow_down_blue_border_selected {
-    border-right: 2px solid black;
-    border-bottom: 2px solid black;
+    border-right: 2px solid #1c1c1c;
+    border-bottom: 2px solid #1c1c1c;
 }
 
 .scb_s_assignments_header_btn > span {

--- a/html_app/ui/assignments.soy
+++ b/html_app/ui/assignments.soy
@@ -104,11 +104,11 @@ Assignment description
         </div>
     <br/>
  		{if $assignments.selected.id=='decusability' or $assignments.selected.course == 'SCB_SampleExercises' }
-        <span class=" scb_s_assignments_print_assignment scb_f_open_experiment scb_s_navigation_button"
-        href="#view=experiment_design&assignment_id={$assignments.selected.id}" id="{$assignments.selected.id}" aria-label='New Experiment' role='button'></span>
+        <a class=" scb_s_assignments_print_assignment scb_f_open_experiment scb_s_navigation_button"
+        href="#view=experiment_design&assignment_id={$assignments.selected.id}" id="{$assignments.selected.id}" aria-label='New Experiment' role='button'></a>
        {/if}
-        <span class="scb_assignments_new_experiment scb_f_open_experiment scb_s_navigation_button"
-        href="#view=experiment_design&assignment_id={$assignments.selected.id}" aria-label='New Experiment' role='button'> START EXPERIMENTS &nbsp; &#9654;</span>
+        <a class="scb_assignments_new_experiment scb_f_open_experiment scb_s_navigation_button"
+        href="#view=experiment_design&assignment_id={$assignments.selected.id}" aria-label='New Experiment' role='button'> START EXPERIMENTS &nbsp; &#9654;</a>
 
 	{/if}
 </div>

--- a/html_app/ui/assignments.soy
+++ b/html_app/ui/assignments.soy
@@ -114,13 +114,12 @@ Assignment description
         	{if length($assignments.selected.template.instructions)>1}
         	    <div class='scb_s_assignments_bottom_scroll'>
        				<button
-                        class = 'scb_s_assignments_header_btn_left scb_assignments_bottom_btn_left scb_s_assignments_header_btn_left_inactive'
+                        class = 'scb_s_assignments_header_btn_left scb_s_assignments_bottom_btn_left scb_s_assignments_header_btn_left_inactive'
                         assignment_id='{$assignments.selected.id}'
                         aria-label='Previous Section'>
                     </button>
-       				<div class='scb_s_assignments_button_divider'></div>
     				<button
-                        class = 'scb_s_assignments_header_btn_right scb_assignments_bottom_btn_right'
+                        class = 'scb_s_assignments_header_btn_right scb_s_assignments_bottom_btn_right'
                         assignment_id='{$assignments.selected.id}'
                         aria-label='Next Section'>
                     </button>

--- a/html_app/ui/assignments.soy
+++ b/html_app/ui/assignments.soy
@@ -69,33 +69,30 @@ Assignment description
             {$assignments.selected.name |noAutoescape}
         </div>
         <div class='scb_s_assignments_slider_header'>
-    		<div
-                class='scb_s_assignment_header_img_left scb_s_assignment_header_img_left_inactive'
-                assignment_id='{$assignments.selected.id}'
-                role='button'
-                aria-label='Previous Section'>
-            </div>
-            {foreach $section in $assignments.selected.template.instructions}
-    		    <div
-                    class='scb_assignments_header_link_wrapper scb_s_assignments_slider_overview {if index($section) == $assignments.selected.last_instruction}scb_assignments_header_link_selected{/if}'
+    		<button class='scb_s_assignments_header_btn_left scb_s_assignments_header_btn_left_inactive'
                     assignment_id='{$assignments.selected.id}'
-                    role='link'
+                    aria-label='Previous Section'>
+            </button>
+            {foreach $section in $assignments.selected.template.instructions}
+    		    <button
+                    class='scb_s_assignments_header_btn {if index($section) == $assignments.selected.last_instruction}scb_s_assignments_header_btn_selected{/if}'
+                    assignment_id='{$assignments.selected.id}'
                     title='{$section[0]}'
                     value='{$section[0]}'
                     aria-controls='scb_s_assignment_scroll'
                     aria-atomic='true'>
                     <span>{$section[0]}</span>
                     {if index($section) == $assignments.selected.last_instruction}
-                        <div class="arrow-down-blue"></div>
+                        <span class='arrow_down_blue_background'></span>
+                        <span class='arrow_down_blue_border arrow_down_blue_border_selected'></span>
                     {/if}
-                </div>
+                </button>
     		{/foreach}
-    		<div
-                class = 'scb_s_assignment_header_img_right {if length($assignments.selected.template.instructions)<2}scb_s_assignment_header_img_right_inactive{/if}'
+            <button
+                class = 'scb_s_assignments_header_btn_right {if length($assignments.selected.template.instructions)<2}scb_s_assignments_header_btn_right_inactive{/if}'
                 assignment_id='{$assignments.selected.id}'
-                role='button'
                 aria-label='Next Section'>
-            </div>
+            </button>
     	</div>
     	<div class='scb_s_assignments_gray_bar'></div>
         <div class='scb_s_assignment_scroll' id ='scb_s_assignment_scroll'  aria-live="assertive">
@@ -116,19 +113,17 @@ Assignment description
             {/foreach}
         	{if length($assignments.selected.template.instructions)>1}
         	    <div class='scb_s_assignments_bottom_scroll'>
-       				<div
-                        class = 'scb_s_assignment_header_img_left scb_assignments_bottom_arrow_left scb_s_assignment_header_img_left_inactive' 
+       				<button
+                        class = 'scb_s_assignments_header_btn_left scb_assignments_bottom_btn_left scb_s_assignments_header_btn_left_inactive'
                         assignment_id='{$assignments.selected.id}'
-                        role='button'
                         aria-label='Previous Section'>
-                    </div>
+                    </button>
        				<div class='scb_s_assignments_button_divider'></div>
-    				<div
-                        class = 'scb_s_assignment_header_img_right scb_assignments_bottom_arrow_right'
+    				<button
+                        class = 'scb_s_assignments_header_btn_right scb_assignments_bottom_btn_right'
                         assignment_id='{$assignments.selected.id}'
-                        role='button'
                         aria-label='Next Section'>
-                    </div>
+                    </button>
 			    </div>
 			{/if}
         </div>

--- a/html_app/ui/assignments.soy
+++ b/html_app/ui/assignments.soy
@@ -12,10 +12,9 @@
 {template .main}
 <div class='scb_s_assignments_view' >
     {call scb_homepage.display_header}
-    {param global_template:$global_template /}
-    {param context:$context /}
+        {param global_template:$global_template /}
+        {param context:$context /}
     {/call}
-    
     {call scb_common.assignment_step}
         {param step:1/}
         {param last_step: $last_step/}
@@ -23,17 +22,17 @@
         {param assignments:assignments/}
     {/call}
     <div class='scb_s_assignments_container' role='main'>
-    {call .display_assignments}
-        {param assignments:$assignments/}
-        {param courses:$courses/}
-    {/call}
-    {call .display_assignment}
-    {param global_template:$global_template /}
-    {param assignments:$assignments/}
-    {/call}
+        {call .display_assignments}
+            {param assignments:$assignments/}
+            {param courses:$courses/}
+        {/call}
+        {call .display_assignment}
+            {param global_template:$global_template /}
+            {param assignments:$assignments/}
+        {/call}
     </div>
     {call scb_homepage.display_footer}
-    {param global_template:$global_template /}
+        {param global_template:$global_template /}
     {/call}
 </div>
 {/template}
@@ -44,7 +43,7 @@ Assignment title
 */
 {template .display_header}
 <div class='scb_s_header'>
-        {$global_template.app_title}
+    {$global_template.app_title}
 </div>
 {/template}
 
@@ -54,7 +53,7 @@ Assignment footer
 */
 {template .display_footer}
 <div class='scb_s_footer'>
-        Here comes footer
+    Here comes footer
 </div>
 {/template}
 
@@ -65,25 +64,46 @@ Assignment description
 {template .display_assignment}
 
 <div class='scb_s_abstract scb_s_assignments_description'>
-
     {if $assignments.selected != null}
     	<div class='scb_s_abstract_title'>
             {$assignments.selected.name |noAutoescape}
         </div>
-
-	<div class='scb_s_assignments_slider_header'>
-		<div class = 'scb_s_assignment_header_img_left scb_s_assignment_header_img_left_inactive'  assignment_id='{$assignments.selected.id}'  role='button' aria-label='Previous Section'></div>
-
-
-		 {foreach $section in $assignments.selected.template.instructions}
-		  <div class='scb_assignments_header_link_wrapper scb_s_assignments_slider_overview {if index($section) == $assignments.selected.last_instruction}scb_assignments_header_link_selected{/if}' assignment_id='{$assignments.selected.id}' role='link' title='{$section[0]}'   value='{$section[0]}' aria-controls='scb_s_assignment_scroll' aria-atomic='true' ><span>{$section[0]}</span>{if index($section) == $assignments.selected.last_instruction}<div class="arrow-down-blue"></div>{/if}</div>
-		{/foreach}
-		<div class = 'scb_s_assignment_header_img_right {if length($assignments.selected.template.instructions)<2}scb_s_assignment_header_img_right_inactive{/if}'  assignment_id='{$assignments.selected.id}' role='button' aria-label='Next Section' ></div>
-	</div>
-	<div class='scb_s_assignments_gray_bar'></div>
+        <div class='scb_s_assignments_slider_header'>
+    		<div
+                class='scb_s_assignment_header_img_left scb_s_assignment_header_img_left_inactive'
+                assignment_id='{$assignments.selected.id}'
+                role='button'
+                aria-label='Previous Section'>
+            </div>
+            {foreach $section in $assignments.selected.template.instructions}
+    		    <div
+                    class='scb_assignments_header_link_wrapper scb_s_assignments_slider_overview {if index($section) == $assignments.selected.last_instruction}scb_assignments_header_link_selected{/if}'
+                    assignment_id='{$assignments.selected.id}'
+                    role='link'
+                    title='{$section[0]}'
+                    value='{$section[0]}'
+                    aria-controls='scb_s_assignment_scroll'
+                    aria-atomic='true'>
+                    <span>{$section[0]}</span>
+                    {if index($section) == $assignments.selected.last_instruction}
+                        <div class="arrow-down-blue"></div>
+                    {/if}
+                </div>
+    		{/foreach}
+    		<div
+                class = 'scb_s_assignment_header_img_right {if length($assignments.selected.template.instructions)<2}scb_s_assignment_header_img_right_inactive{/if}'
+                assignment_id='{$assignments.selected.id}'
+                role='button'
+                aria-label='Next Section'>
+            </div>
+    	</div>
+    	<div class='scb_s_assignments_gray_bar'></div>
         <div class='scb_s_assignment_scroll' id ='scb_s_assignment_scroll'  aria-live="assertive">
-        	{foreach $section in $assignments.selected.template.instructions}
-				<div class='scb_s_display_section' style='display:{if index($section) == $assignments.selected.last_instruction}block;{/if}' value='{$section[0]}' >
+            {foreach $section in $assignments.selected.template.instructions}
+    			<div
+                    class='scb_s_display_section'
+                    style='display:{if index($section) == $assignments.selected.last_instruction}block;{/if}'
+                    value='{$section[0]}'>
                     {$section[1] |noAutoescape}
                     {if $assignments.selected.template.files and length($assignments.selected.template.files) > 0}
                         <ul>
@@ -93,24 +113,43 @@ Assignment description
                         </ul>
                     {/if}
                 </div>
-        	{/foreach}
+            {/foreach}
         	{if length($assignments.selected.template.instructions)>1}
-        	<div class='scb_s_assignments_bottom_scroll'>
-   				<div class = 'scb_s_assignment_header_img_left scb_assignments_bottom_arrow_left scb_s_assignment_header_img_left_inactive'  assignment_id='{$assignments.selected.id}'   role='button' aria-label='Previous Section'></div>
-   				<div class='scb_s_assignments_button_divider'></div>
-				<div class = 'scb_s_assignment_header_img_right scb_assignments_bottom_arrow_right'  assignment_id='{$assignments.selected.id}'  role='button' aria-label='Next Section'></div>
-			</div>
+        	    <div class='scb_s_assignments_bottom_scroll'>
+       				<div
+                        class = 'scb_s_assignment_header_img_left scb_assignments_bottom_arrow_left scb_s_assignment_header_img_left_inactive' 
+                        assignment_id='{$assignments.selected.id}'
+                        role='button'
+                        aria-label='Previous Section'>
+                    </div>
+       				<div class='scb_s_assignments_button_divider'></div>
+    				<div
+                        class = 'scb_s_assignment_header_img_right scb_assignments_bottom_arrow_right'
+                        assignment_id='{$assignments.selected.id}'
+                        role='button'
+                        aria-label='Next Section'>
+                    </div>
+			    </div>
 			{/if}
         </div>
-    <br/>
+        <br/>
  		{if $assignments.selected.id=='decusability' or $assignments.selected.course == 'SCB_SampleExercises' }
-        <a class=" scb_s_assignments_print_assignment scb_f_open_experiment scb_s_navigation_button"
-        href="#view=experiment_design&assignment_id={$assignments.selected.id}" id="{$assignments.selected.id}" aria-label='New Experiment' role='button'></a>
-       {/if}
-        <a class="scb_assignments_new_experiment scb_f_open_experiment scb_s_navigation_button"
-        href="#view=experiment_design&assignment_id={$assignments.selected.id}" aria-label='New Experiment' role='button'> START EXPERIMENTS &nbsp; &#9654;</a>
-
-	{/if}
+            <a
+                class=" scb_s_assignments_print_assignment scb_f_open_experiment scb_s_navigation_button"
+                href="#view=experiment_design&assignment_id={$assignments.selected.id}"
+                id="{$assignments.selected.id}"
+                aria-label='New Experiment'
+                role='button'>
+            </a>
+        {/if}
+        <a
+            class="scb_assignments_new_experiment scb_f_open_experiment scb_s_navigation_button"
+            href="#view=experiment_design&assignment_id={$assignments.selected.id}"
+            aria-label='New Experiment'
+            role='button'>
+            START EXPERIMENTS &nbsp; &#9654;
+        </a>
+    {/if}
 </div>
 {/template}
 
@@ -122,22 +161,29 @@ Assignment assignments
 {template .display_assignments}
 <div class='scb_s_assignments_sidebar'>
     <h1 class='scb_s_assignments_sidebar_title'>Assignments: <div class="arrow-down"></div></h1>
-    <ul aria-label="Assignments"  >
+    <ul aria-label="Assignments">
         {foreach $course in keys($courses)}
             <div class='scb_s_assignments_sidebar_course_block'>
-            <div class='scb_s_assignments_sidebar_course' role='heading'>{$courses[$course].name}</div>
-        {foreach $assignment in $courses[$course]}
+                <div class='scb_s_assignments_sidebar_course' role='heading'>{$courses[$course].name}</div>
+                {foreach $assignment in $courses[$course]}
+                    <li
+                        role="link"
+                        class='scb_s_assignments_sidebar_name {if $assignments.selected.id == $assignment.id}scb_s_assignments_sidebar_name_selected{/if}'
+                        aria-selected='{if $assignments.selected.id == $assignment.id}true{else}false{/if}'>
+        				<a
+                            role='presentation'
+                            href='#view=assignments&assignment_id={$assignment.id}'
+                            model_id='{$assignment.id}'
+                            class='scb_s_assignment_sidebar_link {if $assignment.id == $assignments.selected_id}scb_f_open_assignment{else}scb_f_select_assignment{/if}'>
+                            {$assignment.name}
 
-			<li role="link" class='scb_s_assignments_sidebar_name {if $assignments.selected.id == $assignment.id}scb_s_assignments_sidebar_name_selected{/if}' aria-selected='{if $assignments.selected.id == $assignment.id}true{else}false{/if}'  >
-				<a role='presentation' href='#view=assignments&assignment_id={$assignment.id}' model_id='{$assignment.id}' class='scb_s_assignment_sidebar_link {if $assignment.id == $assignments.selected_id}scb_f_open_assignment{else}scb_f_select_assignment{/if}'>{$assignment.name}
-
-				</a>
-				{if $assignments.selected.id == $assignment.id}
-					<div class='scb_s_selection_arrow_img'></div>
-				{/if}
-			</li>
-        {/foreach}
-        </div>
+        				</a>
+        				{if $assignments.selected.id == $assignment.id}
+        					<div class='scb_s_selection_arrow_img'></div>
+        				{/if}
+        			</li>
+                {/foreach}
+            </div>
         {/foreach}
     </ul>
 </div>
@@ -150,15 +196,27 @@ Assignment experiments
 */
 {template .display_experiments}
 <ul class='scb_s_assignment_experiment_list'>
-{if length($experiments.list) != 0}
-    {foreach $experiment in $experiments.list}
-    <li class='scb_s_assignment_experiment_list_item'>
-        <a class='scb_f_open_assignment_experiment' href='#view=experiment_last&assignment_id={$assignment.id}&experiment_id={$experiment.id}' model_id='{$assignment.id}' sub_model_id='{$experiment.id}'>{$experiment.name}</a>
-    </li>
-    {/foreach}
-{/if}
+    {if length($experiments.list) != 0}
+        {foreach $experiment in $experiments.list}
+            <li class='scb_s_assignment_experiment_list_item'>
+                <a
+                    class='scb_f_open_assignment_experiment'
+                    href='#view=experiment_last&assignment_id={$assignment.id}&experiment_id={$experiment.id}'
+                    model_id='{$assignment.id}'
+                    sub_model_id='{$experiment.id}'>
+                    {$experiment.name}
+                </a>
+            </li>
+        {/foreach}
+    {/if}
 </ul>
-    <div class='scb_s_assignment_experiment_list_item_new_experiment'>
-       <span aria-hidden="true" tabindex="-1">+</span><a class='scb_f_new_assignment_experiment scb_s_new_assignment_experiment' href='#view=experiment_design&assignment_id={$assignment.id}' model_id='{$assignment.id}'>New Experiment</a>
-    </div>
+<div class='scb_s_assignment_experiment_list_item_new_experiment'>
+    <span aria-hidden="true" tabindex="-1">+</span>
+    <a
+        class='scb_f_new_assignment_experiment scb_s_new_assignment_experiment'
+        href='#view=experiment_design&assignment_id={$assignment.id}'
+        model_id='{$assignment.id}'>
+        New Experiment
+    </a>
+</div>
 {/template}

--- a/html_app/ui/auth.gss
+++ b/html_app/ui/auth.gss
@@ -6,91 +6,84 @@
   /* @alternate */ background-image: -o-linear-gradient(POS, START_COLOR, END_COLOR);   /* Opera 11.10+ */
 }
 
-
 .scb_s_login_dialog > iframe, .scb_s_logout_dialog > iframe{
-	right:6px;
-	bottom:6px;
+    right: 6px;
+    bottom: 6px;
     background: #f4f6f8;
     border-radius: 5px;
     padding: 10px;
     height: 322px;
     width: 398px;
     border-bottom-right-radius: 9px;
-	border-bottom-left-radius: 9px;
-    border:0;
-    overflow:hidden;
-    display:block;
-    margin-left:0px;
+    border-bottom-left-radius: 9px;
+    border: 0;
+    overflow: hidden;
+    display: block;
+    margin-left: 0px;
     position: relative;
-	z-index: 999;
+    z-index: 999;
     font-family: 'sourcesanspro-bold';
     font-size: 10pt;
-    
 }
 
-
 .scb_s_signup_dialog > iframe {
-	right:6px;
-	bottom:6px;
+    right: 6px;
+    bottom: 6px;
     background: #f4f6f8;
     border-radius: 5px;
     padding: 10px;
     height: 560px;
     width: 398px;
     border-bottom-right-radius: 9px;
-	border-bottom-left-radius: 9px;
-    border:0;
-    overflow:hidden;
-    display:block;
-    margin-left:0px;
+    border-bottom-left-radius: 9px;
+    border: 0;
+    overflow: hidden;
+    display: block;
+    margin-left: 0px;
     position: relative;
-	z-index: 999;
+    z-index: 999;
     font-family: 'sourcesanspro-bold';
     font-size: 10pt;
-    
 }
 
-.scb_s_login_form >div, .scb_s_signup_form >div{
-	display: inline-block;
-	position: relative;
-	left: 8px;
+.scb_s_login_form > div, .scb_s_signup_form > div {
+    display: inline-block;
+    position: relative;
+    left: 8px;
 }
 
-.scb_s_login_form, .scb_s_signup_form{
-	background: #27956c;
+.scb_s_login_form, .scb_s_signup_form {
+    background: #27956c;
     color: white;
     padding: 10px;
     height: 25px;
     width: 398px;
     position: relative;
-	right: 6px;
-	bottom: 6px;
-	font-family: 'sourcesanspro-semibold';
-	border-top-left-radius: 9px;
-	border-top-right-radius: 9px;
+    right: 6px;
+    bottom: 6px;
+    font-family: 'sourcesanspro-semibold';
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
     font-size: 13pt;
     letter-spacing: 0.5px;
 }
 
-
-.scb_s_login_dialog, .scb_s_logout_dialog{
-	z-index: 99;
+.scb_s_login_dialog, .scb_s_logout_dialog {
+    z-index: 99;
     position: absolute;
     background: white;
     border-radius: 13px;
     box-shadow: 0px 0px 36px gray;
-    margin-left:400px;
-    margin-right:400px;
+    margin-left: 400px;
+    margin-right: 400px;
     margin-top: 200px;
     padding: 10px;
     height: 375px;
     width: 406px;
-    top:0px;
+    top: 0px;
     font-family: 'sourcesanspro-bold';
     font-size: 10pt;
-    
 }
-
 
 .scb_s_signup_dialog {
     height: 613px !important;
@@ -99,47 +92,41 @@
     background: white;
     border-radius: 13px;
     box-shadow: 0px 0px 36px gray;
-    margin-left:400px;
-    margin-right:400px;
+    margin-left: 400px;
+    margin-right: 400px;
     margin-top: 50px;
     padding: 10px;
     width: 406px;
-    top:0px;
+    top: 0px;
     font-family: 'sourcesanspro-bold';
     font-size: 10pt;
-    
 }
 
-.scb_f_login_close_button, .scb_f_signup_close_button, .scb_f_logout_close_button, .scb_f_sort_close_button{
-
-	
-	padding-top: 0px;
-	float:right;
-	-webkit-appearance: none;
-	font-family:'sourcesanspro-semibold';
-	outline:none;
-	height: 26px;
-	width: 26px;
-	cursor:pointer;
-	border: none;
-	border-radius: 12px;
-	font-size: 14pt;
-	color: transparent;
-	background: transparent;
-	background-image: url('../../images/header/scb_close_button.png');
-	padding-right: 4px;
-	padding-left: 5px;
-	
+.scb_f_login_close_button, .scb_f_signup_close_button, .scb_f_logout_close_button, .scb_f_sort_close_button {
+    padding-top: 0px;
+    float: right;
+    -webkit-appearance: none;
+    font-family: 'sourcesanspro-semibold';
+    outline: none;
+    height: 26px;
+    width: 26px;
+    cursor: pointer;
+    border: none;
+    border-radius: 12px;
+    font-size: 14pt;
+    color: transparent;
+    background: transparent;
+    background-image: url('../../images/header/scb_close_button.png');
+    padding-right: 4px;
+    padding-left: 5px;
 }
 
-
-
-.scb_f_login_close_button>span, .scb_f_sort_close_button>span,  .scb_f_signup_close_button>span, .scb_f_logout_close_button>span{
-	position: relative;
-	bottom: 2px;
-	right: 1px;
+.scb_f_login_close_button > span, .scb_f_sort_close_button > span, .scb_f_signup_close_button>span, .scb_f_logout_close_button > span {
+    position: relative;
+    bottom: 2px;
+    right: 1px;
 }
 
-.scb_f_login_close_button:hover, .scb_f_sort_close_button:hover, .scb_f_signup_close_button:hover, .scb_f_logout_close_button:hover{
-	background-color: #e58986;
+.scb_f_login_close_button:hover, .scb_f_sort_close_button:hover, .scb_f_signup_close_button:hover, .scb_f_logout_close_button:hover {
+    background-color: #e58986;
 }

--- a/html_app/ui/common.gss
+++ b/html_app/ui/common.gss
@@ -401,14 +401,12 @@ div#main {
 .arrow-down-select {
     width: 0;
     height: 0;
-    border-left: 20px solid transparent;
-    border-right: 20px solid transparent;
-    border-top: 20px solid #4690C1;
+    border-left: 15px solid transparent;
+    border-right: 15px solid transparent;
+    border-top: 15px solid #4690C1;
     position: absolute;
-}
-
-.arrow-down-select {
-    left: 74px;
+    left: 79px;
+    top: 35px;
 }
 
 .scb_s_experiment_step_text {

--- a/html_app/ui/common.gss
+++ b/html_app/ui/common.gss
@@ -594,7 +594,8 @@ label.custom-select {
     vertical-align: middle;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-family: 'sourcesanspro-semibold'
+    font-family: 'sourcesanspro-semibold';
+    outline-offset: -10px;
 }
 
 .scb_s_assignment_step_link_active {

--- a/html_app/ui/common.gss
+++ b/html_app/ui/common.gss
@@ -23,7 +23,7 @@
     border: 0;
 }
 
-input[type=text], textarea {
+input[type='text'], input[type='number'], textarea {
     border: 1px solid #a9a9a9;
 }
 

--- a/html_app/ui/common.gss
+++ b/html_app/ui/common.gss
@@ -23,6 +23,10 @@
     border: 0;
 }
 
+input[type=text], textarea {
+    border: 1px solid #a9a9a9;
+}
+
 .dummy {
 }
 

--- a/html_app/ui/common.gss
+++ b/html_app/ui/common.gss
@@ -451,7 +451,6 @@ div#main {
 label.custom-select {
     position: relative;
     display: inline-block;
-    height: 19px;
 }
 
 .custom-select:hover {
@@ -460,13 +459,16 @@ label.custom-select {
 
 .custom-select {
     width: 219px;
-    height: 21px;
-    padding-top: 4px;
-    padding-bottom: 3px;
+    height: 24px;
+    padding-top: 2px;
     padding-left: 10px;
     overflow: hidden;
     background: url("../images/setup/scb_experiment_dropdown.png") no-repeat right #FFF;
     box-shadow: inset 1px 1px 3px 1px rgba(0, 0, 0, 0.3);
+}
+
+.custom-select:focus-within {
+   box-shadow: 0 0 2px 2px #1c1c1c; /* Default focus indicator */
 }
 
 .custom-select select {
@@ -476,12 +478,15 @@ label.custom-select {
    font-family: Arial;
    font-weight: normal;
    font-size: 10pt;
-   line-height: 1;
    border: 0;
    border-radius: 0;
    height: 22px;
    -webkit-appearance: none;
    bottom: 1px;
+}
+
+.custom-select select:focus {
+    box-shadow: none;
 }
 
 #jqDialog_options > button {

--- a/html_app/ui/common.gss
+++ b/html_app/ui/common.gss
@@ -6,6 +6,19 @@
   /* @alternate */ background-image: -o-linear-gradient(POS, START_COLOR, END_COLOR);   /* Opera 11.10+ */
 }
 
+/* By default, use box shadows instead of outlines to show focus */
+*:focus {
+    outline: none;
+    box-shadow: 0 0 2px 2px #1c1c1c;
+}
+
+/* In certain cases (packed buttons for example), outlines are preferable */
+.enable-outline:focus {
+    outline: 2px solid #1c1c1c;
+    box-shadow: none;
+}
+
+/* Disable Firefox's inner focus outline */
 ::-moz-focus-inner {
     border: 0;
 }

--- a/html_app/ui/common.gss
+++ b/html_app/ui/common.gss
@@ -6,11 +6,11 @@
   /* @alternate */ background-image: -o-linear-gradient(POS, START_COLOR, END_COLOR);   /* Opera 11.10+ */
 }
 
-.dummy {
+::-moz-focus-inner {
+    border: 0;
 }
 
-::-moz-focus-inner {
-	border:0;
+.dummy {
 }
 
 body {
@@ -18,29 +18,31 @@ body {
 }
 
 div#main {
-	position: relative;
-	width: 1002px;
+    position: relative;
+    width: 1002px;
 }
 
-.scb_f_assignments_step_link{
-	width:202px !important;
-}
-.scb_f_experiments_step_link{
-	width: 178px !important;
-}
-.scb_f_lab_notebook_link{
-	width: 176px !important;
+.scb_f_assignments_step_link {
+    width: 202px !important;
 }
 
-.scb_f_open_experiment{
-	margin-top: 0px !important;
+.scb_f_experiments_step_link {
+    width: 178px !important;
 }
 
-
-.scb_f_open_experiment_top{
-	background: #c82e3e !important;
-	position: absolute !important;
+.scb_f_lab_notebook_link {
+    width: 176px !important;
 }
+
+.scb_f_open_experiment {
+    margin-top: 0px !important;
+}
+
+.scb_f_open_experiment_top {
+    background: #c82e3e !important;
+    position: absolute !important;
+}
+
 .scb_s_navigation_button_old {
    /*background-image: url('../images/homepage/instructor_resources_button.png');*/
     padding: 3px 20px 3px 20px;
@@ -49,7 +51,7 @@ div#main {
     color: white;
     text-decoration: none;
     text-align: center;
-    font-size:11pt;
+    font-size: 11pt;
     letter-spacing: 1px;
     border-radius: 5px;
     margin-top: 10px;
@@ -58,64 +60,56 @@ div#main {
     margin-bottom: 5px;
     box-shadow: 0px 0px 5px #a9a9a9;
     font-family:'sourcesanspro-regular';
-    cursor:pointer;
+    cursor: pointer;
     @mixin gradient(top,#81c9f1,#028dde,#008ddd);
-
 }
 
-
-.contact_overlay{
-	width: 100%;
-	height: 100%;
-	position: fixed;
-	z-index: 98; 
-	background: rgba(0,0,0,0);
-	visibility: visible;
-	right: 0px;
-	top: 0px;
+.contact_overlay {
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    z-index: 98;
+    background: rgba(0,0,0,0);
+    visibility: visible;
+    right: 0px;
+    top: 0px;
 }
-
 
 .scb_s_navigation_button {
-	
-	float: right;
-	-webkit-appearance: none;
-	border-radius: 8px;
-	letter-spacing: 1px;
-	text-transform: uppercase;
-	background: #27956c;
-	padding-top: 5px;
-	height: 20px;
-	color: white;
-	text-decoration: none;
-	text-align: center;
-	font-size: 9pt;
-	font-family:'sourcesanspro-semibold';
-	cursor: pointer;
-	position:relative;
-	margin-top: 10px;
-	margin-left: 5px;
-	margin-right: 5px;
-	margin-bottom: 5px;
-	background-position: center;
-	padding-left: 13px;
-	padding-right: 9px;
-	bottom:8px;
-	top:1px;
-
+    float: right;
+    -webkit-appearance: none;
+    border-radius: 8px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    background: #27956c;
+    padding-top: 5px;
+    height: 20px;
+    color: white;
+    text-decoration: none;
+    text-align: center;
+    font-size: 9pt;
+    font-family:'sourcesanspro-semibold';
+    cursor: pointer;
+    position:relative;
+    margin-top: 10px;
+    margin-left: 5px;
+    margin-right: 5px;
+    margin-bottom: 5px;
+    background-position: center;
+    padding-left: 13px;
+    padding-right: 9px;
+    bottom: 8px;
+    top: 1px;
 }
 
-.scb_s_navigation_button:hover{
-	background: #0a694a;
-
+.scb_s_navigation_button:hover {
+    background: #0a694a;
 }
-
 
 .scb_s_experiment_step {
     position: relative;
     display: inline-block;
     right: -7px;
-
 }
 
 .scb_s_experiment_step_circle {
@@ -127,51 +121,49 @@ div#main {
     vertical-align: 90%;
     color: white;
     display: block;
-    margin-left:2em;
-    margin-right:2em;
+    margin-left: 2em;
+    margin-right: 2em;
     @mixin gradient(top,#6e6e6e,#373737,#383838);
 }
 
-
-.scb_s_experiment_step_button{
-	font-family: 'sourcesanspro-regular';
-	color: white !important;
-    border-radius:5px;
-	background: #d5dce4;
-	margin-right: 10px;
-	height: 24px;
-	width:140px;
-	text-align:center;
-	padding: 3px 9px 3px 12px;
+.scb_s_experiment_step_button {
+    font-family: 'sourcesanspro-regular';
+    color: white !important;
+    border-radius: 5px;
+    background: #d5dce4;
+    margin-right: 10px;
+    height: 24px;
+    width: 140px;
+    text-align:center;
+    padding: 3px 9px 3px 12px;
 }
 
-.scb_s_experiment_step_button>a{
-	color:white;
+.scb_s_experiment_step_button > a {
+    color: white;
 }
 
-.scb_s_experiment_step_visited{
-	background:#59BBF2 !important;
+.scb_s_experiment_step_visited {
+    background: #59BBF2 !important;
 }
 
-.scb_s_experiment_step_buttons_title{
-	font-family:'sourcesanspro-bold';
-	color: #d5dce4;
-	padding: 27px 20px 0px 20px;
+.scb_s_experiment_step_buttons_title {
+    font-family: 'sourcesanspro-bold';
+    color: #d5dce4;
+    padding: 27px 20px 0px 20px;
 }
-.scb_s_experiment_step_active_title{
-	
-	color: #316f94 !important;
+.scb_s_experiment_step_active_title {
+    color: #316f94 !important;
 }
 
-.scb_s_experiment_step_labels{
-	width: 460px;
-	display: inline-block;
+.scb_s_experiment_step_labels {
+    width: 460px;
+    display: inline-block;
 }
 
 .scb_s_experiment_step_number {
     padding: .25em .25em .25em .25em;
     vertical-align: top;
-    font-size:16pt;
+    font-size: 16pt;
 }
 
 .scb_experiment_step_selected {
@@ -181,14 +173,15 @@ div#main {
 .scb_experiment_step_previous {
     @mixin gradient(top,#88d2af,#18968a,#189689);
 }
-.scb_s_experiment_step_visited{
-	background: #4dbcf5;
+
+.scb_s_experiment_step_visited {
+    background: #4dbcf5;
 }
 
-.scb_s_experiment_step_green_bar{
-	position:relative;
-	z-index: 6;
-	border: 1px solid #8f8e8c;
+.scb_s_experiment_step_green_bar {
+    position:relative;
+    z-index: 6;
+    border: 1px solid #8f8e8c;
     width: 440px;
     height: 20px;
     border-radius: 18px;
@@ -196,12 +189,12 @@ div#main {
     vertical-align: 90%;
     color: white;
     display: block;
-    margin-right:2em;
-	@mixin gradient(top,#27956c,#189689,#189689);
+    margin-right: 2em;
+    @mixin gradient(top,#27956c,#189689,#189689);
 }
 
-.scb_s_experiment_step_black_bar{
-	position:relative;
+.scb_s_experiment_step_black_bar {
+    position:relative;
     width: 440px;
     height: 22px;
     border-radius: 18px;
@@ -209,220 +202,196 @@ div#main {
     vertical-align: 90%;
     color: white;
     display: block;
-    margin-left:2em;
-    margin-right:2em;
+    margin-left: 2em;
+    margin-right: 2em;
     @mixin gradient(top,#6e6e6e,#373737,#383838);
 }
 
-
-
-
-
-
-.scb_s_experiment_step_progress_label{
+.scb_s_experiment_step_progress_label {
     padding: 5px;
-	text-align: center;
-	left: 5px;
-	letter-spacing: 1px;
-	font-size: 13pt;
-	vertical-align: middle;
-	text-decoration: none;
-	color: #316f94;
-	display: inline-block;
-	position: relative;
-	font-family: 'sourcesanspro-bold';
-	bottom: 10px;
+    text-align: center;
+    left: 5px;
+    letter-spacing: 1px;
+    font-size: 13pt;
+    vertical-align: middle;
+    text-decoration: none;
+    color: #316f94;
+    display: inline-block;
+    position: relative;
+    font-family: 'sourcesanspro-bold';
+    bottom: 10px;
 }
-
-
 
 .scb_s_experiment_step_div {
     display:inline-block;
-    margin:5px;
+    margin: 5px;
     margin-left: 15px;
     height: 112px;
-	width: 887px;
-	color:white;
-	border-radius:8px;
+    width: 887px;
+    color:white;
+    border-radius: 8px;
     vertical-align: top;
     margin-bottom: 10px;
 }
 
-.scb_s_experiment_step_design{
-	width: 77px;
-	left: 0px;
-	border-top-left-radius: 8px;
-	height: inherit;
-	padding: 10px;
-	border-bottom-left-radius: 8px;
+.scb_s_experiment_step_design {
+    width: 77px;
+    left: 0px;
+    border-top-left-radius: 8px;
+    height: inherit;
+    padding: 10px;
+    border-bottom-left-radius: 8px;
 }
 
-.scb_s_experiment_step_setup_and_run{
-	width: 137px;
+.scb_s_experiment_step_setup_and_run {
+    width: 137px;
 }
 
-.scb_s_experiment_step_select_technique{
-	width: 186px;
+.scb_s_experiment_step_select_technique {
+    width: 186px;
 }
 
-.scb_s_experiment_step_text >a{
-	color:white;
+.scb_s_experiment_step_text > a {
+    color: white;
 }
 
-.scb_s_experiment_step_tech_steps{
-	height: 66px;
-	width: 887px;
-	font-size: 13pt;
-	letter-spacing: 1px;
-	background: white;
-	border-bottom-left-radius: 8px;
-	border-bottom-right-radius: 8px;
-	position: absolute;
-	z-index: 4;
-	top: 99px;
+.scb_s_experiment_step_tech_steps {
+    height: 66px;
+    width: 887px;
+    font-size: 13pt;
+    letter-spacing: 1px;
+    background: white;
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+    position: absolute;
+    z-index: 4;
+    top: 99px;
 }
 
-.scb_s_experiment_step_tech_steps > div{
-		display: inline-block;
-}
-.scb_s_experiment_step_main_steps{
-	background: #e9ecf1;
-	height: 42px;
-	border-radius: 8px;
-	width: 887px;
-	position: absolute;
-	z-index: 5;
+.scb_s_experiment_step_tech_steps > div {
+    display: inline-block;
 }
 
-.scb_s_experiment_step_selected{
-	background: #4690C1 !important;
+.scb_s_experiment_step_main_steps {
+    background: #e9ecf1;
+    height: 42px;
+    border-radius: 8px;
+    width: 887px;
+    position: absolute;
+    z-index: 5;
 }
 
-
-
-.arrow-design-outer{
-	width: 0;
-	height: 0;
-	border-top: 22px solid transparent;
-	border-bottom: 22px solid transparent;
-	border-left: 11px solid white;
-	left: 97px;
-	top: -1px;
-	z-index: 56;
-	position: absolute;
+.scb_s_experiment_step_selected {
+    background: #4690C1 !important;
 }
 
-.arrow-setup-outer{
-	width: 0;
-	height: 0;
-	border-top: 22px solid transparent;
-	border-bottom: 22px solid transparent;
-	border-left: 11px solid white;
-	left: 157px;
-	top: -1px;
-	z-index: 56;
-	position: absolute;
+.arrow-design-outer {
+    width: 0;
+    height: 0;
+    border-top: 22px solid transparent;
+    border-bottom: 22px solid transparent;
+    border-left: 11px solid white;
+    left: 97px;
+    top: -1px;
+    z-index: 56;
+    position: absolute;
 }
 
-
-.arrow-down-design{
-
-	width: 0;
-	height: 0;
-	border-top: 20px solid transparent;
-	border-bottom: 20px solid transparent;
-	border-left: 9px solid #d5dce4;
-	left: -12px;
-	top: -20px;
-	position: absolute;
-	z-index: 56;
+.arrow-setup-outer {
+    width: 0;
+    height: 0;
+    border-top: 22px solid transparent;
+    border-bottom: 22px solid transparent;
+    border-left: 11px solid white;
+    left: 157px;
+    top: -1px;
+    z-index: 56;
+    position: absolute;
 }
 
-
-.arrow-down-setup{
-
-	width: 0;
-	height: 0;
-	border-top: 20px solid transparent;
-	border-bottom: 20px solid transparent;
-	border-left: 9px solid #d5dce4;
-	left: -12px;
-	top: -20px;
-	position: absolute;
-	z-index: 56;
+.arrow-down-design {
+    width: 0;
+    height: 0;
+    border-top: 20px solid transparent;
+    border-bottom: 20px solid transparent;
+    border-left: 9px solid #d5dce4;
+    left: -12px;
+    top: -20px;
+    position: absolute;
+    z-index: 56;
 }
 
-
-
-
-
-.arrow-down-design-selected{
-
-	width: 0;
-	height: 0;
-	border-top: 20px solid transparent;
-	border-bottom: 20px solid transparent;
-	border-left: 9px solid #4690c1 !important;
-	left: -12px;
-	top: -20px;
-	position: absolute;
-	z-index: 56;
+.arrow-down-setup {
+    width: 0;
+    height: 0;
+    border-top: 20px solid transparent;
+    border-bottom: 20px solid transparent;
+    border-left: 9px solid #d5dce4;
+    left: -12px;
+    top: -20px;
+    position: absolute;
+    z-index: 56;
 }
 
-
-.arrow-down-design-visited{
-
-	width: 0;
-	height: 0;
-	border-top: 20px solid transparent;
-	border-bottom: 20px solid transparent;
-	border-left: 9px solid #59bbf2 !important;
-	left: -12px;
-	top: -20px;
-	position: absolute;
-	z-index: 56;
+.arrow-down-design-selected {
+    width: 0;
+    height: 0;
+    border-top: 20px solid transparent;
+    border-bottom: 20px solid transparent;
+    border-left: 9px solid #4690c1 !important;
+    left: -12px;
+    top: -20px;
+    position: absolute;
+    z-index: 56;
 }
 
-
-.arrow-down-setup-visited{
-	width: 0;
-	height: 0;
-	border-top: 20px solid transparent;
-	border-bottom: 20px solid transparent;
-	border-left: 9px solid #59bbf2 !important;
-	left: -12px;
-	top: -20px;
-	z-index: 56;
-	position: absolute;
-} 
-
-.arrow-down-setup-selected{
-	width: 0;
-	height: 0;
-	border-top: 20px solid transparent;
-	border-bottom: 20px solid transparent;
-	border-left: 9px solid #4690c1 !important;
-	left: -12px;
-	top: -20px;
-	z-index: 56;
-	position: absolute;
-} 
-
-
-.arrow-down-select{
-	width: 0; 
-	height: 0; 
-	border-left: 20px solid transparent;
-	border-right: 20px solid transparent;
-	border-top: 20px solid #4690C1;
-	position: absolute;
-	
+.arrow-down-design-visited {
+    width: 0;
+    height: 0;
+    border-top: 20px solid transparent;
+    border-bottom: 20px solid transparent;
+    border-left: 9px solid #59bbf2 !important;
+    left: -12px;
+    top: -20px;
+    position: absolute;
+    z-index: 56;
 }
 
+.arrow-down-setup-visited {
+    width: 0;
+    height: 0;
+    border-top: 20px solid transparent;
+    border-bottom: 20px solid transparent;
+    border-left: 9px solid #59bbf2 !important;
+    left: -12px;
+    top: -20px;
+    z-index: 56;
+    position: absolute;
+}
 
+.arrow-down-setup-selected {
+    width: 0;
+    height: 0;
+    border-top: 20px solid transparent;
+    border-bottom: 20px solid transparent;
+    border-left: 9px solid #4690c1 !important;
+    left: -12px;
+    top: -20px;
+    z-index: 56;
+    position: absolute;
+}
 
-.arrow-down-select{
-	left: 74px;
+.arrow-down-select {
+    width: 0;
+    height: 0;
+    border-left: 20px solid transparent;
+    border-right: 20px solid transparent;
+    border-top: 20px solid #4690C1;
+    position: absolute;
+}
+
+.arrow-down-select {
+    left: 74px;
 }
 
 .scb_s_experiment_step_text {
@@ -433,7 +402,7 @@ div#main {
     vertical-align: top;
     font-size: 12pt;
     letter-spacing: 1px;
-	background: #d5dce4;
+    background: #d5dce4;
 }
 
 .scb_s_assignment_step_experiment_block {
@@ -441,13 +410,12 @@ div#main {
     top: -25px;
     left: 300px;
     color: black;
-    font-size:12pt;
+    font-size: 12pt;
     overflow-x: hidden;
     width: 660px;
 }
 
-.scb_s_experiment_step_text_two_line{
-	
+.scb_s_experiment_step_text_two_line {
 }
 
 .scb_s_assignment_step_experiment {
@@ -458,42 +426,34 @@ div#main {
 .scb_s_assignment_step_experiment_line {
     position: absolute;
     top: 10px;
-    height:1px;
+    height: 1px;
     background-color: #14ac63;
-    font-size:13pt;
+    font-size: 13pt;
 }
 
-
-
-
-
- label.custom-select {
+label.custom-select {
     position: relative;
     display: inline-block;
-	height: 19px;
+    height: 19px;
 }
 
-.custom-select:hover{
-  background: url("../images/setup/scb_experiment_dropdown_hover.png") no-repeat right #FFF;
-
+.custom-select:hover {
+    background: url("../images/setup/scb_experiment_dropdown_hover.png") no-repeat right #FFF;
 }
 
-.custom-select {  
-	
-	width: 219px;
-	
-	height: 21px;
-	padding-top: 4px;
-	padding-bottom: 3px;
-	padding-left: 10px;
-	overflow: hidden;
-	background: url("../images/setup/scb_experiment_dropdown.png") no-repeat right #FFF;
-	box-shadow: inset 1px 1px 3px 1px rgba(0, 0, 0, 0.3);
+.custom-select {
+    width: 219px;
+    height: 21px;
+    padding-top: 4px;
+    padding-bottom: 3px;
+    padding-left: 10px;
+    overflow: hidden;
+    background: url("../images/setup/scb_experiment_dropdown.png") no-repeat right #FFF;
+    box-shadow: inset 1px 1px 3px 1px rgba(0, 0, 0, 0.3);
 }
 
 .custom-select select {
-
-	background: transparent;
+   background: transparent;
    width: 268px;
    color: #316f94;
    font-family: Arial;
@@ -505,91 +465,85 @@ div#main {
    height: 22px;
    -webkit-appearance: none;
    bottom: 1px;
-
 }
 
-
-
 #jqDialog_options > button {
-	@mixin gradient(top,#f2f2f2, #d3d1d2, #ffffff);
+    @mixin gradient(top,#f2f2f2, #d3d1d2, #ffffff);
     border: 1px solid #e0e0e0;
     border-radius: 5pt;
     height: 30px;
     color: black;
     font-size: 10pt;
     font-family: 'sourcesanspro-semibold';
-    cursor:pointer;
-    text-transform:uppercase;
+    cursor: pointer;
+    text-transform: uppercase;
 }
-
 
 .scb_s_assignment_step_experiment_box {
     position: relative;
     top:5px;
 }
 
-.scb_s_assignment_step_experiment > label{
-	cursor: pointer;
-}
-.scb_s_assignment_step_experiment > label> select{
-	cursor: pointer;
+.scb_s_assignment_step_experiment > label {
+    cursor: pointer;
 }
 
-.scb_s_assignments_link_img{
-	background-image:url('../images/header/scb_assignment_off.png');
-	background-repeat:no-repeat;
-	height: 26px;
-	width: 36px;
-	margin-right: 15px;
+.scb_s_assignment_step_experiment > label > select {
+    cursor: pointer;
 }
 
-.scb_s_experiments_link_img{
-	background-image:url('../images/header/scb_experiments_off.png');
-	background-repeat:no-repeat;
-	height: 22px;
-	width: 22px;
-	margin-right: 15px;
+.scb_s_assignments_link_img {
+    background-image: url('../images/header/scb_assignment_off.png');
+    background-repeat: no-repeat;
+    height: 26px;
+    width: 36px;
+    margin-right: 15px;
 }
 
-.scb_s_lab_notebook_link_img{
-	background-image:url('../images/header/scb_labnotebook_off.png');
-	background-repeat:no-repeat;
-	height: 22px;
-	width: 22px;
-	margin-right: 15px;
+.scb_s_experiments_link_img {
+    background-image: url('../images/header/scb_experiments_off.png');
+    background-repeat: no-repeat;
+    height: 22px;
+    width: 22px;
+    margin-right: 15px;
 }
 
-
-.scb_s_assignments_link_img_active{
-	background-image:url('../images/header/scb_assignment_on.png');
-	background-repeat:no-repeat;
-	height: 26px;
-	width: 36px;
-	margin-right: 15px;
+.scb_s_lab_notebook_link_img {
+    background-image: url('../images/header/scb_labnotebook_off.png');
+    background-repeat: no-repeat;
+    height: 22px;
+    width: 22px;
+    margin-right: 15px;
 }
 
-.scb_s_experiments_link_img_active{
-	background-image:url('../images/header/scb_experiments_on.png');
-	background-repeat:no-repeat;
-	height: 22px;
-	width: 22px;
-	margin-right: 15px;
+.scb_s_assignments_link_img_active {
+    background-image: url('../images/header/scb_assignment_on.png');
+    background-repeat: no-repeat;
+    height: 26px;
+    width: 36px;
+    margin-right: 15px;
 }
 
-.scb_s_lab_notebook_link_img_active{
-	background-image:url('../images/header/scb_labnotebook_on.png');
-	background-repeat:no-repeat;
-	height: 22px;
-	width: 22px;
-	margin-right: 15px;
+.scb_s_experiments_link_img_active {
+    background-image: url('../images/header/scb_experiments_on.png');
+    background-repeat: no-repeat;
+    height: 22px;
+    width: 22px;
+    margin-right: 15px;
 }
 
-.scb_s_assignment_step_wrapper{
-	display:inline-flex;
-	vertical-align: middle;
+.scb_s_lab_notebook_link_img_active {
+    background-image: url('../images/header/scb_labnotebook_on.png');
+    background-repeat: no-repeat;
+    height: 22px;
+    width: 22px;
+    margin-right: 15px;
 }
 
-
+.scb_s_assignment_step_wrapper {
+    display: inline-flex;
+    vertical-align: middle;
+}
 
 .scb_s_assignment_step {
     background: #d5dce4;
@@ -598,10 +552,11 @@ div#main {
     height: 70px;
     position: relative;
     text-transform:uppercase;
-	box-shadow: 0 9px 9px -2px #939aa3 inset
+    box-shadow: 0 9px 9px -2px #939aa3 inset
 }
+
 .scb_s_assignment_step > img {
-    height:69px;
+    height: 69px;
     top: 1px;
     margin-left: -11px;
     margin-right:-13px;
@@ -609,33 +564,32 @@ div#main {
 }
 
 .scb_s_selection_arrow_img{
-    background-image:url('../images/homepage/selection_arrow.png');
+    background-image: url('../images/homepage/selection_arrow.png');
     background-repeat: no-repeat;
-    float:right;
+    float: right;
     height: 15px;
     width: 22px;
 }
 
 .scb_f_open_experiment_top:hover{
-	background-color: #8a1825 !important;
+    background-color: #8a1825 !important;
 }
 
-
 .scb_s_assignment_step_link {
-    width:140px;
-    height:60px;
-    padding:5px;
-    padding-left:10px;
-    padding-right:10px;
+    width: 140px;
+    height: 60px;
+    padding: 5px;
+    padding-left: 10px;
+    padding-right: 10px;
     text-align: center;
     letter-spacing: 1px;
-    font-size:12pt;
+    font-size: 12pt;
     text-decoration: none;
-    color:#316f94;
+    color: #316f94;
     overflow: hidden;
     border-left: 1px solid gray;
-	border-right: 1px solid gray;
-	box-shadow: 0px 1px 0px 1px white;
+    border-right: 1px solid gray;
+    box-shadow: 0px 1px 0px 1px white;
     display: table-cell;
     vertical-align: middle;
     text-overflow: ellipsis;
@@ -644,14 +598,14 @@ div#main {
 }
 
 .scb_s_assignment_step_link_active {
-	background:#8d97a3;
-	box-shadow: inset 0 6px 17px -2px black;
+    background: #8d97a3;
+    box-shadow: inset 0 6px 17px -2px black;
     margin-left: -1px;
     color: white;
 }
 
 .scb_s_gray_button {
-	background-color: #676767;
+    background-color: #676767;
     border: 1px solid #e0e0e0;
     border-radius: 5pt;
     height: 30px;
@@ -659,10 +613,9 @@ div#main {
     letter-spacing:1px;
     font-size: 10pt;
     font-family: 'sourcesanspro-regular';
-    cursor:pointer;
+    cursor: pointer;
 }
 
 .scb_s_gray_button:hover{
-	background-color: #464747;
-	
+    background-color: #464747;
 }

--- a/html_app/ui/common.gss
+++ b/html_app/ui/common.gss
@@ -499,6 +499,7 @@ label.custom-select {
     font-family: 'sourcesanspro-semibold';
     cursor: pointer;
     text-transform: uppercase;
+    margin-left: 3px;
 }
 
 .scb_s_assignment_step_experiment_box {

--- a/html_app/ui/common.gss
+++ b/html_app/ui/common.gss
@@ -9,6 +9,10 @@
 .dummy {
 }
 
+::-moz-focus-inner {
+	border:0;
+}
+
 body {
     background-color: #e9edf1;
 }

--- a/html_app/ui/common.soy
+++ b/html_app/ui/common.soy
@@ -53,14 +53,14 @@
 
 {if $step > 0}
     <div class='scb_s_assignment_step' role='menu' xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html" role='navigation'>
-        <a class='scb_s_assignment_step_link scb_f_assignments_step_link {if $step < 2 and $step > 0}scb_s_assignment_step_link_active{/if}' href='#view=assignments' aria-label='Assignments' role='menuitem'>
+        <a class='scb_s_assignment_step_link scb_f_assignments_step_link enable-outline {if $step < 2 and $step > 0}scb_s_assignment_step_link_active{/if}' href='#view=assignments' aria-label='Assignments' role='menuitem'>
             <div class='scb_s_assignment_step_wrapper' style='position: absolute; left: 29px; bottom: 20px;' aria-hidden='true'>
                 <div class='{if $step < 2 and $step > 0}scb_s_assignments_link_img_active{else}scb_s_assignments_link_img {/if}' role='presentation'>
                 </div>
                 ASSIGNMENTS
             </div>
         </a>
-        <a role='menuitem' class='scb_s_assignment_step_link scb_f_experiments_step_link {if $step >= 2 and $step < 10 }scb_s_assignment_step_link_active{/if}'
+        <a role='menuitem' class='scb_s_assignment_step_link scb_f_experiments_step_link enable-outline {if $step >= 2 and $step < 10 }scb_s_assignment_step_link_active{/if}'
             href=
             {if $assignments and not $assignments.selected.experiments.selected}
                 '#view=experiment_design&assignment_id={$aid}'

--- a/html_app/ui/common.soy
+++ b/html_app/ui/common.soy
@@ -9,99 +9,102 @@
 @param prev_step
 */
 {template .assignment_step}
-{let $eid} 
-		{if $assignments}
-			{$assignments.selected.experiments.selected_id}
-		{elseif $assignment}
-			 {$assignment.experiments.selected_id}
-		{elseif $experiment}
-		   	{$experiment.id}
-		{/if} 
+{let $eid}
+    {if $assignments}
+        {$assignments.selected.experiments.selected_id}
+    {elseif $assignment}
+        {$assignment.experiments.selected_id}
+    {elseif $experiment}
+        {$experiment.id}
+    {/if}
 {/let}
 
-{let $aid} 
-		{if $assignments}
-			{$assignments.selected_id}
-		{elseif $assignment}
-			 {$assignment.id}
-		{/if} 
-{/let}
-{let $wbid} 
-		{if $assignments and $assignments.selected.experiments.selected}
-			{$assignments.selected.experiments.selected.western_blot_list.selected_id}
-		{elseif $assignment}
-			 {$assignment.experiments.selected.western_blot_list.selected_id}
-		{/if} 
+{let $aid}
+    {if $assignments}
+        {$assignments.selected_id}
+    {elseif $assignment}
+        {$assignment.id}
+    {/if}
 {/let}
 
-{let $fid} 
-		{if $assignments and $assignments.selected.experiments.selected}
-			{$assignments.selected.experiments.selected.facs_list.selected_id}
-		{elseif $assignment}
-			 {$assignment.experiments.selected.facs_list.selected_id}
-		{/if} 
+{let $wbid}
+    {if $assignments and $assignments.selected.experiments.selected}
+        {$assignments.selected.experiments.selected.western_blot_list.selected_id}
+    {elseif $assignment}
+        {$assignment.experiments.selected.western_blot_list.selected_id}
+    {/if}
 {/let}
 
-{let $mid} 
-		{if $assignments and $assignments.selected.experiments.selected}
-			{$assignments.selected.experiments.selected.microscopy_list.selected_id}
-		{elseif $assignment}
-			 {$assignment.experiments.selected.microscopy_list.selected_id}
-		{/if} 
+{let $fid}
+    {if $assignments and $assignments.selected.experiments.selected}
+        {$assignments.selected.experiments.selected.facs_list.selected_id}
+    {elseif $assignment}
+        {$assignment.experiments.selected.facs_list.selected_id}
+    {/if}
 {/let}
 
-{if $step >0}
-<div class='scb_s_assignment_step' role='menu' xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html" role='navigation'>
-    <a class='scb_s_assignment_step_link scb_f_assignments_step_link {if $step < 2 and $step >0}scb_s_assignment_step_link_active{/if}' href='#view=assignments' aria-label='Assignments' role='menuitem' >
-        <div class='scb_s_assignment_step_wrapper' style='position: absolute; left: 29px; bottom: 20px;' aria-hidden='true'>
-			<div class='{if $step < 2 and $step >0}scb_s_assignments_link_img_active{else}scb_s_assignments_link_img {/if}' role='presentation' ></div>
-			ASSIGNMENTS
-        </div>
-    </a>
-    <a role='menuitem' class='scb_s_assignment_step_link scb_f_experiments_step_link {if $step >= 2 and $step < 10 }scb_s_assignment_step_link_active{/if}'
-       href=
-       {if $assignments and  not $assignments.selected.experiments.selected}
-       '#view=experiment_design&assignment_id={$aid}'
-       {elseif $prev_step == 1 or $prev_step == 10}
-       '#view=experiment_design&assignment_id={$aid}&experiment_id={$eid}' 
-       {elseif $prev_step == 2}
-       '#view=experiment_setup&assignment_id={$aid}&experiment_id={$eid}' 
-       {elseif $prev_step == 3}
-       '#view=select_technique&assignment_id={$aid}&experiment_id={$eid}' 
-       {elseif $prev_step == 4 }
-       '#view=western_blot&assignment_id={$aid}&experiment_id={$eid}&western_blot_id={$wbid}'
-       {elseif $prev_step == 4 and not $wbid=='null'}
-       '#view=western_blot&assignment_id={$aid}&experiment_id={$eid}'  
-       {elseif $prev_step == 5 }
-       '#view=facs&assignment_id={$aid}&experiment_id={$eid}&facs_id={$fid}' 
-       {elseif $prev_step == 5 and not $fid=='null'}
-       '#view=facs&assignment_id={$aid}&experiment_id={$eid}' 
-       {elseif $prev_step == 6 }
-       '#view=microscopy&assignment_id={$aid}&experiment_id={$eid}&microscopy_id={$mid}' 
-       {elseif $prev_step == 6 and not $mid=='null'}
-       '#view=microscopy&assignment_id={$aid}&experiment_id={$eid}' 
-       {else}
-       '#view=experiment_design'
-       {/if}
-       
-       
-       aria-label='Experiments' >
-       <div class='scb_s_assignment_step_wrapper'  aria-hidden='true'>
+{let $mid}
+    {if $assignments and $assignments.selected.experiments.selected}
+        {$assignments.selected.experiments.selected.microscopy_list.selected_id}
+    {elseif $assignment}
+        {$assignment.experiments.selected.microscopy_list.selected_id}
+    {/if}
+{/let}
 
-		   <div class='{if $step >= 2 and $step < 10 }scb_s_experiments_link_img_active{else}scb_s_experiments_link_img {/if}' role='presentation' ></div>
-				EXPERIMENTS
-    	</div>
-    </a>
-    <!-- Enable LAB REPORT button -->
-    <!--<a role='menuitem' class='scb_s_assignment_step_link scb_f_lab_notebook_link {if $step == 10 }scb_s_assignment_step_link_active{/if}' aria-label='Lab Notebook' aria-disabled='true' href='#view=notebook&assignment_id={$aid}'>
-    	<div class='scb_s_assignment_step_wrapper'  aria-hidden='true'>
-			<div class='{if $step == 10 }scb_s_lab_notebook_link_img_active{else}scb_s_lab_notebook_link_img {/if}    ' role='presentation' ></div>
-			LAB REPORT
-        </div>
-    </a>-->
-</div>
+{if $step > 0}
+    <div class='scb_s_assignment_step' role='menu' xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html" role='navigation'>
+        <a class='scb_s_assignment_step_link scb_f_assignments_step_link {if $step < 2 and $step > 0}scb_s_assignment_step_link_active{/if}' href='#view=assignments' aria-label='Assignments' role='menuitem'>
+            <div class='scb_s_assignment_step_wrapper' style='position: absolute; left: 29px; bottom: 20px;' aria-hidden='true'>
+                <div class='{if $step < 2 and $step > 0}scb_s_assignments_link_img_active{else}scb_s_assignments_link_img {/if}' role='presentation'>
+                </div>
+                ASSIGNMENTS
+            </div>
+        </a>
+        <a role='menuitem' class='scb_s_assignment_step_link scb_f_experiments_step_link {if $step >= 2 and $step < 10 }scb_s_assignment_step_link_active{/if}'
+            href=
+            {if $assignments and not $assignments.selected.experiments.selected}
+                '#view=experiment_design&assignment_id={$aid}'
+            {elseif $prev_step == 1 or $prev_step == 10}
+                '#view=experiment_design&assignment_id={$aid}&experiment_id={$eid}'
+            {elseif $prev_step == 2}
+                '#view=experiment_setup&assignment_id={$aid}&experiment_id={$eid}'
+            {elseif $prev_step == 3}
+                '#view=select_technique&assignment_id={$aid}&experiment_id={$eid}'
+            {elseif $prev_step == 4 }
+                '#view=western_blot&assignment_id={$aid}&experiment_id={$eid}&western_blot_id={$wbid}'
+            {elseif $prev_step == 4 and not $wbid=='null'}
+               '#view=western_blot&assignment_id={$aid}&experiment_id={$eid}'
+            {elseif $prev_step == 5 }
+               '#view=facs&assignment_id={$aid}&experiment_id={$eid}&facs_id={$fid}'
+            {elseif $prev_step == 5 and not $fid=='null'}
+               '#view=facs&assignment_id={$aid}&experiment_id={$eid}'
+            {elseif $prev_step == 6 }
+               '#view=microscopy&assignment_id={$aid}&experiment_id={$eid}&microscopy_id={$mid}'
+            {elseif $prev_step == 6 and not $mid=='null'}
+               '#view=microscopy&assignment_id={$aid}&experiment_id={$eid}'
+            {else}
+               '#view=experiment_design'
+            {/if}
+            aria-label='Experiments' >
+            <div class='scb_s_assignment_step_wrapper'  aria-hidden='true'>
+                <div class='{if $step >= 2 and $step < 10}scb_s_experiments_link_img_active{else}scb_s_experiments_link_img {/if}' role='presentation' >
+                </div>
+                EXPERIMENTS
+            </div>
+        </a>
+        <!-- Enable LAB REPORT button -->
+        <!--
+        <a role='menuitem' class='scb_s_assignment_step_link scb_f_lab_notebook_link {if $step == 10 }scb_s_assignment_step_link_active{/if}' aria-label='Lab Notebook' aria-disabled='true' href='#view=notebook&assignment_id={$aid}'>
+            <div class='scb_s_assignment_step_wrapper'  aria-hidden='true'>
+                <div class='{if $step == 10}scb_s_lab_notebook_link_img_active{else}scb_s_lab_notebook_link_img {/if}    ' role='presentation' ></div>
+                LAB REPORT
+            </div>
+        </a>
+        -->
+    </div>
 {/if}
 {/template}
+
 /**
 Progress bar
 @param step
@@ -111,130 +114,99 @@ Progress bar
 */
 {template .experiment_step}
 <div class='scb_s_experiment_step' role='navigation'>
-	
-	<div id='scb_s_experiment_step_progress_label_for_assignment' class = 'scb_s_experiment_step_progress_label' role='presentation'> {$assignment.name}:</div>
-	
-		<div class='scb_s_assignment_step_experiment' aria-labelledby='scb_s_experiment_step_progress_label_for_assignment'>
-			
-				<label role='presentation' class="custom-select">
-
-					<select role='select'  aria-label='Experiments' alt='' onchange="location = this.value;">
-						{foreach $e in $assignment.experiments.list}
-							<option role='option' aria-label='{$e.name}' value="#view=experiment_last&assignment_id={$assignment.id}&experiment_id={$e.id}{if $e.last_view == 'microscopy'}&microscopy_id={$e.microscopy_list.selected_id}{elseif $e.last_view == 'facs'}&facs_id={$e.facs_list.selected_id}{elseif $e.last_view == 'western_blot' or $e.last_view == 'western_blot_gel'}&western_blot_id={$e.western_blot_list.selected_id}{/if}" 
-								model_id='{$assignment.id}' sub_model_id='{$experiment.id}'
-								{if  $experiment.id  == $e.id}selected="selected"{/if}> 
-								{$e.name}&nbsp;&nbsp;
-								
-							</option>
-						{/foreach}
-					</select>
-					
-				</label>
-			</div>
-			<a class="scb_f_open_experiment scb_f_open_experiment_top scb_s_navigation_button" href="#view=experiment_design&assignment_id={$assignment.id}" aria-label='New Experiment' role='button'> NEW EXPERIMENT &nbsp; <span aria-hidden="true" tabindex="-1">+</span></a>
-
-	
-	<br/>
-	<br/>
-    <div class="scb_s_experiment_step_div " role='presentation' style='height:{if $step>3 or   $last_step >4} 112px {else} 112px{/if}' >
-    	
-    	<div class='scb_s_experiment_step_main_steps '>
-			<div class='scb_s_experiment_step_labels' aria-live='polite'>
-				<div class='scb_s_experiment_step_text scb_s_experiment_step_design {if $step>1 or  $last_step > 0}scb_s_experiment_step_visited{/if} {if $step==1 }scb_s_experiment_step_selected{/if}' aria-label='Experiment Design' aria-disabled='{if $step > 1 or  $last_step > 0 or $step==1 }false{else}true{/if}' role ='button'>
-
-					{if $step>1 or  $last_step > 0}
-					<a href='#view=experiment_design&assignment_id={$assignment.id}&experiment_id={$experiment.id}'  role='presentation' >1. DESIGN</a>
-
-					{else}
-					1. DESIGN
-					{/if}
-					
-					
-				<div class="arrow-design-outer" role='presentation' >
-						<div role='presentation'  class="arrow-down-design {if $step==1 }arrow-down-design-selected{elseif $step>1 or  $last_step > 0}arrow-down-design-visited {/if}"></div>
-				</div>
-					{if $step==1 } 
-
-					{/if}	
-				</div>
-		
-				<div class='scb_s_experiment_step_text scb_s_experiment_step_setup_and_run {if $step>2 or $last_step > 3}scb_s_experiment_step_visited{/if} {if $step==2 or $step==3 }scb_s_experiment_step_selected{/if}' aria-label='Setup and Run Experiment'  aria-disabled='{if $step>2 or $last_step > 3 or $step==2 or $step==3}false{else}true{/if}' role ='button' >
-
-					
-					
-					{if $step>2 or $last_step > 3}
-					<a href='#view=experiment_setup&assignment_id={$assignment.id}&experiment_id={$experiment.id}' role='presentation' >2. SETUP & RUN</a>
-						
-					{else}
-					2. SETUP & RUN
-					{/if}
-					<div class="arrow-setup-outer" role='presentation' >
-						<div role='presentation'  class="arrow-down-setup {if $step>2 or $last_step > 3}arrow-down-setup-visited{/if} {if $step==2 or $step==3 }arrow-down-setup-selected{/if}"></div>
-					
-					</div>
-					{if $step==2 or $step==3 }
-					{/if}
-				
-				</div>
-		
-				<div class='scb_s_experiment_step_text scb_s_experiment_step_select_technique {if $step>3 or   $last_step >4}scb_s_experiment_step_visited{/if} {if $step>3 }scb_s_experiment_step_selected{/if}'   aria-label='Select Experiment Technique' aria-disabled='{if $step>3 or   $last_step >4  or $step>3}false{else}true{/if}' role ='button'>
-
-					
-					{if $step>3 or   $last_step >4}
-					<a href='#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}' role='presentation' >3. SELECT TECHNIQUE</a>
-
-					{else}
-					3. SELECT TECHNIQUE
-					{/if}
-					{if $step>3 }
-						<div class="arrow-down-select" role='presentation' ></div>
-					{/if}
-					
-				</div>
-			</div>
+    <div id='scb_s_experiment_step_progress_label_for_assignment' class = 'scb_s_experiment_step_progress_label' role='presentation'> {$assignment.name}:</div>
+        <div class='scb_s_assignment_step_experiment' aria-labelledby='scb_s_experiment_step_progress_label_for_assignment'>
+            <label role='presentation' class="custom-select">
+                <select role='select'  aria-label='Experiments' alt='' onchange="location = this.value;">
+                    {foreach $e in $assignment.experiments.list}
+                        <option role='option' aria-label='{$e.name}' value="#view=experiment_last&assignment_id={$assignment.id}&experiment_id={$e.id}{if $e.last_view == 'microscopy'}&microscopy_id={$e.microscopy_list.selected_id}{elseif $e.last_view == 'facs'}&facs_id={$e.facs_list.selected_id}{elseif $e.last_view == 'western_blot' or $e.last_view == 'western_blot_gel'}&western_blot_id={$e.western_blot_list.selected_id}{/if}"
+                            model_id='{$assignment.id}' sub_model_id='{$experiment.id}'
+                            {if  $experiment.id  == $e.id}selected="selected"{/if}>
+                            {$e.name}&nbsp;&nbsp;
+                        </option>
+                    {/foreach}
+                </select>
+            </label>
+        </div>
+        <a class="scb_f_open_experiment scb_f_open_experiment_top scb_s_navigation_button" href="#view=experiment_design&assignment_id={$assignment.id}" aria-label='New Experiment' role='button'> NEW EXPERIMENT &nbsp; <span aria-hidden="true" tabindex="-1">+</span></a>
+        <br>
+        <br>
+        <div class="scb_s_experiment_step_div " role='presentation' style='height:{if $step>3 or   $last_step >4} 112px {else} 112px{/if}' >
+            <div class='scb_s_experiment_step_main_steps '>
+                <div class='scb_s_experiment_step_labels' aria-live='polite'>
+                    <div class='scb_s_experiment_step_text scb_s_experiment_step_design {if $step>1 or  $last_step > 0}scb_s_experiment_step_visited{/if} {if $step==1 }scb_s_experiment_step_selected{/if}' aria-label='Experiment Design' aria-disabled='{if $step > 1 or  $last_step > 0 or $step==1 }false{else}true{/if}' role ='button'>
+                        {if $step>1 or  $last_step > 0}
+                            <a href='#view=experiment_design&assignment_id={$assignment.id}&experiment_id={$experiment.id}'  role='presentation' >1. DESIGN</a>
+                        {else}
+                            1. DESIGN
+                        {/if}
+                        <div class="arrow-design-outer" role='presentation' >
+                            <div role='presentation'  class="arrow-down-design {if $step==1 }arrow-down-design-selected{elseif $step>1 or  $last_step > 0}arrow-down-design-visited {/if}">
+                            </div>
+                        </div>
+                        {if $step==1 }
+                        {/if}
+                </div>
+                <div class='scb_s_experiment_step_text scb_s_experiment_step_setup_and_run {if $step>2 or $last_step > 3}scb_s_experiment_step_visited{/if} {if $step==2 or $step==3 }scb_s_experiment_step_selected{/if}' aria-label='Setup and Run Experiment'  aria-disabled='{if $step>2 or $last_step > 3 or $step==2 or $step==3}false{else}true{/if}' role ='button' >
+                    {if $step>2 or $last_step > 3}
+                        <a href='#view=experiment_setup&assignment_id={$assignment.id}&experiment_id={$experiment.id}' role='presentation' >2. SETUP & RUN</a>
+                    {else}
+                        2. SETUP & RUN
+                    {/if}
+                    <div class="arrow-setup-outer" role='presentation' >
+                        <div role='presentation'  class="arrow-down-setup {if $step>2 or $last_step > 3}arrow-down-setup-visited{/if} {if $step==2 or $step==3 }arrow-down-setup-selected{/if}">
+                        </div>
+                    </div>
+                    {if $step==2 or $step==3 }
+                    {/if}
+                </div>
+                <div class='scb_s_experiment_step_text scb_s_experiment_step_select_technique {if $step>3 or   $last_step >4}scb_s_experiment_step_visited{/if} {if $step>3 }scb_s_experiment_step_selected{/if}'   aria-label='Select Experiment Technique' aria-disabled='{if $step>3 or   $last_step >4  or $step>3}false{else}true{/if}' role ='button'>
+                    {if $step>3 or   $last_step >4}
+                        <a href='#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}' role='presentation' >3. SELECT TECHNIQUE</a>
+                    {else}
+                        3. SELECT TECHNIQUE
+                    {/if}
+                    {if $step>3 }
+                        <div class="arrow-down-select" role='presentation' ></div>
+                    {/if}
+                </div>
+            </div>
         </div>
         <div class='scb_s_experiment_step_tech_steps ' role='presentation'  style='{if length($experiment.western_blot_list) > 0 or length($experiment.facs_list) > 0 or length($experiment.microscopy_list) > 0}{else}display:none;{/if}'>
-			<div class='scb_s_experiment_step_buttons_title scb_s_experiment_step_active_title'>Perform Your Technique: </div>
-						<div class='scb_s_experiment_step_button scb_s_experiment_step_button_wb {if length($experiment.western_blot_list) > 0}scb_s_experiment_step_visited{/if} {if $step==5 }scb_s_experiment_step_selected{/if}'  aria-disabled='{if length($experiment.western_blot_list) > 0 or $step==5}false{else}true{/if}' role ='button' aria-label='Start Western Blotting'>
-							{if length($experiment.western_blot_list) <= 0 or  $step==5 }
-							Western Blotting
-							{else}
-							<a role='presentation'  href='#view=western_blot&assignment_id={$assignment.id}&experiment_id={$experiment.id}&western_blot_id={$experiment.western_blot_list.selected_id}'>Western Blotting</a>
-							{/if}
-						</div>
-						<div class=' scb_s_experiment_step_button scb_s_experiment_step_button_facs {if length($experiment.facs_list) > 0}scb_s_experiment_step_visited{/if} {if $step==6 }scb_s_experiment_step_selected{/if}'  aria-disabled='{if length($experiment.facs_list) > 0 or $step==6}false{else}true{/if}' role ='button'  aria-label='Start Flow Cytometry'>
-							
-							{if length($experiment.facs_list) <= 0 or $step==6 }
-							Flow Cytometry
-							{else}
-							<a role='presentation'  href='#view=facs&assignment_id={$assignment.id}&experiment_id={$experiment.id}&facs_id={$experiment.facs_list.selected_id}'>Flow Cytometry</a>
-							{/if}
-						</div>
-						<div class='scb_s_experiment_step_button scb_s_experiment_step_button_micro {if length($experiment.microscopy_list) > 0}scb_s_experiment_step_visited{/if} {if $step==7 }scb_s_experiment_step_selected{/if}'  aria-disabled='{if length($experiment.microscopy_list) > 0 or $step==7}false{else}true{/if}' role ='button' aria-label='Start Microscopy'>
-							{if length($experiment.microscopy_list) <= 0 or $step==7}
-							Microscopy	
-							{else}
-							<a role='presentation'  href='#view=microscopy&assignment_id={$assignment.id}&experiment_id={$experiment.id}&microscopy_id={$experiment.microscopy_list.selected_id}'>Microscopy</a>
-							{/if}
-						</div>
-
-			
-       		 </div>
-
-    	</div>
+            <div class='scb_s_experiment_step_buttons_title scb_s_experiment_step_active_title'>Perform Your Technique:
+            </div>
+            <div class='scb_s_experiment_step_button scb_s_experiment_step_button_wb {if length($experiment.western_blot_list) > 0}scb_s_experiment_step_visited{/if} {if $step==5 }scb_s_experiment_step_selected{/if}'  aria-disabled='{if length($experiment.western_blot_list) > 0 or $step==5}false{else}true{/if}' role ='button' aria-label='Start Western Blotting'>
+                {if length($experiment.western_blot_list) <= 0 or  $step==5 }
+                    Western Blotting
+                {else}
+                    <a role='presentation'  href='#view=western_blot&assignment_id={$assignment.id}&experiment_id={$experiment.id}&western_blot_id={$experiment.western_blot_list.selected_id}'>Western Blotting</a>
+                {/if}
+            </div>
+            <div class=' scb_s_experiment_step_button scb_s_experiment_step_button_facs {if length($experiment.facs_list) > 0}scb_s_experiment_step_visited{/if} {if $step==6 }scb_s_experiment_step_selected{/if}'  aria-disabled='{if length($experiment.facs_list) > 0 or $step==6}false{else}true{/if}' role ='button'  aria-label='Start Flow Cytometry'>
+                {if length($experiment.facs_list) <= 0 or $step==6 }
+                    Flow Cytometry
+                {else}
+                    <a role='presentation'  href='#view=facs&assignment_id={$assignment.id}&experiment_id={$experiment.id}&facs_id={$experiment.facs_list.selected_id}'>Flow Cytometry</a>
+                {/if}
+            </div>
+            <div class='scb_s_experiment_step_button scb_s_experiment_step_button_micro {if length($experiment.microscopy_list) > 0}scb_s_experiment_step_visited{/if} {if $step==7 }scb_s_experiment_step_selected{/if}'  aria-disabled='{if length($experiment.microscopy_list) > 0 or $step==7}false{else}true{/if}' role ='button' aria-label='Start Microscopy'>
+                {if length($experiment.microscopy_list) <= 0 or $step==7}
+                    Microscopy
+                {else}
+                    <a role='presentation'  href='#view=microscopy&assignment_id={$assignment.id}&experiment_id={$experiment.id}&microscopy_id={$experiment.microscopy_list.selected_id}'>Microscopy</a>
+                {/if}
+            </div>
+        </div>
+    </div>
 </div>
-
-
-
 {/template}
+
 /**
 * Contact  Overlay
 */
 {template .contact_overlay}
 <div class='contact_overlay' role='presentation'></div>
-
 {/template}
-
 
 /**
 * Format time - from parts
@@ -254,7 +226,6 @@ Progress bar
 {if $now}0 sec{/if}
 {/if}
 {/template}
-
 
 /**
 * Format time - from parts

--- a/html_app/ui/common.soy
+++ b/html_app/ui/common.soy
@@ -161,13 +161,13 @@ Progress bar
                     {/if}
                 </div>
                 <div class='scb_s_experiment_step_text scb_s_experiment_step_select_technique {if $step>3 or   $last_step >4}scb_s_experiment_step_visited{/if} {if $step>3 }scb_s_experiment_step_selected{/if}'   aria-label='Select Experiment Technique' aria-disabled='{if $step>3 or   $last_step >4  or $step>3}false{else}true{/if}' role ='button'>
+                    {if $step>3 }
+                        <div class="arrow-down-select" role='presentation' ></div>
+                    {/if}
                     {if $step>3 or   $last_step >4}
                         <a href='#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}' role='presentation' >3. SELECT TECHNIQUE</a>
                     {else}
                         3. SELECT TECHNIQUE
-                    {/if}
-                    {if $step>3 }
-                        <div class="arrow-down-select" role='presentation' ></div>
                     {/if}
                 </div>
             </div>

--- a/html_app/ui/experiment_setup.gss
+++ b/html_app/ui/experiment_setup.gss
@@ -18,19 +18,20 @@
     text-align: justify;
     display: inline-block;
     vertical-align: top;
-    min-height:350px;
+    min-height: 350px;
     padding: 10px;
-    width:912px;
+    width: 912px;
     margin-left: 35px;
     border-radius: 8px;
     background: #f5f6f8;
 }
 
-.scb_s_experiment_setup_top{
-	position:relative;
+.scb_s_experiment_setup_top {
+    position: relative;
 }
+
 .scb_f_open_experiment_design {
-    float:left !important;
+    float: left !important;
     bottom: 5px !important;
     left: 29px !important;
 }
@@ -41,63 +42,61 @@
 }
 
 .scb_f_open_experiment_setup {
-	margin-left: 0px !important;
+    margin-left: 0px !important;
 }
 
 .scb_f_open_experiment_setup_readonly {
     bottom: 5px;
     right: 29px;
-	top: 2px;
-	position:relative;
+    top: 2px;
+    position: relative;
 }
 
-.scb_s_warning_dialog>.scb_f_open_experiment_setup{
-	top: -12px;
+.scb_s_warning_dialog>.scb_f_open_experiment_setup {
+    top: -12px;
     right: 203px !important;
 }
 
 .scb_s_select_technique_container>.scb_f_open_experiment_setup_readonly {
     bottom: 5px;
     left: 29px;
-    float:left;
-	top: 2px;
+    float: left;
+    top: 2px;
 }
 
 .scb_s_experiment_setup_details_view>.scb_f_open_select_technique {
-    float:right;
+    float: right;
     bottom: 3px;
     right: 29px;
-    position:absolute;
+    position: absolute;
 }
 
 .scb_s_experiment_setup_container>.scb_f_open_select_technique {
-    float:right;
+    float: right;
     bottom: 3px;
     right: 29px !important;
-    
-} 
+}
 
 .scb_s_warning_dialog>.scb_f_open_select_technique {
-    float:right;
+    float: right;
     top: 2px;
     position: relative;
     right: 50px;
 }
 
-
 .scb_s_experiment_setup_choose_template {
     width: 600px;
     display: block;
     left: 11px;
-	position: relative;
-	top: -4px;
+    position: relative;
+    top: -4px;
 }
 
 table.scb_s_experiment_setup_table {
     border: 1px solid #27956c;
-    border-radius:5px;
+    border-radius: 5px;
     border-spacing: 0px;
-    width:98%;
+    width: 98%;
     background-color: white;
     padding-bottom: 2px;
 }
@@ -110,50 +109,45 @@ table.scb_s_experiment_setup_table {
     border-top: 1px solid #e0e0e0;
 }
 
-
-
 .scb_s_experiment_setup_new_set_up{
-	visibility: hidden;	
-	position: relative;
-	margin-top: 109px;
-	margin-bottom: 10px;
-	left: 8px;
+    visibility: hidden;
+    position: relative;
+    margin-top: 109px;
+    margin-bottom: 10px;
+    left: 8px;
 }
-
 
 .scb_s_experiment_setup_td {
 }
 
 .scb_s_experiment_setup_instructions{
-	width: 600px;
-	display: block;
-	bottom: 85px;
-	position: relative;
+    width: 600px;
+    display: block;
+    bottom: 85px;
+    position: relative;
 }
 
 .scb_s_experiment_setup_video_text{
-	color:black;
-	font-size: 7.5pt;
-	font-family: 'sourcesanspro-regular';
-	display: inline-block;
-	margin-left: 15px;
+    color: black;
+    font-size: 7.5pt;
+    font-family: 'sourcesanspro-regular';
+    display: inline-block;
+    margin-left: 15px;
 }
-
 
 .scb_s_experiment_setup_table_element {
 }
 
 .scb_f_experiment_setup_remove_sample, .scb_f_experiment_setup_duplicate_sample {
-    border:0px;
-    width:24px;
+    border: 0px;
+    width: 24px;
     background: transparent;
     height: 20px;
     cursor: pointer;
-    top:0px;
+    top: 0px;
 }
 
 .scb_s_experiment_setup_new_row {
-
 }
 
 .scb_s_experiment_setup_new_row_gray {
@@ -162,13 +156,13 @@ table.scb_s_experiment_setup_table {
 
 .scb_s_experiment_setup_video_box_wrapper {
     width: 199px;
-    height:190px;
-    float:right;
+    height: 190px;
+    float: right;
     background-color: #e1e3e8;
     border-radius: 5px;
     border: 2px solid #f2f3f5;
     position: absolute;
-    top:0px;
+    top: 0px;
     right: 12px;
 
 }
@@ -178,38 +172,38 @@ table.scb_s_experiment_setup_table {
     font-size: 16pt;
     margin-bottom: -27px;
 }
+
 .scb_s_experiment_setup_video_box {
     width: 233px;
-    height:188px;
+    height: 188px;
     background: 0;
     margin-left: 7px;
-    margin-top:27px;
-    overflow:hidden;
+    margin-top: 27px;
+    overflow: hidden;
 }
 
-.scb_s_experiment_setup_container{
-	background: white;
-	padding-bottom: 51px;
-	box-shadow: 0 4px 14px -1px gray;
-	position: relative;
-	z-index: 1;
+.scb_s_experiment_setup_container {
+    background: white;
+    padding-bottom: 51px;
+    box-shadow: 0 4px 14px -1px gray;
+    position: relative;
+    z-index: 1;
 }
 
 .scb_s_experiment_setup_video_box_img {
     width: 187px;
-    height:124px;
+    height: 124px;
     margin-bottom: -5px;
     background-color: #525252;
-
 }
 
 .scb_s_experiment_setup_video_box_placeholder {
-	width: 187px;
-	height: 124px;
-	bottom: 32px;
-	background-color: #525252;
-	position: absolute;
-	left: 6px;
+    width: 187px;
+    height: 124px;
+    bottom: 32px;
+    background-color: #525252;
+    position: absolute;
+    left: 6px;
 }
 
 .scb_s_warning {
@@ -217,47 +211,45 @@ table.scb_s_experiment_setup_table {
     border: 1px solid #d0d0d0;
     border-radius: 10px;
     margin-bottom: 10px;
-    padding: 10px; 
-    width:540px;
+    padding: 10px;
+    width: 540px;
     text-align: left;
 }
 
-nav ul li.on{
-	background: none !important;
-	background-color: #27956c !important;
-	border: 1px solid #000 !important;
-} 
+nav ul li.on {
+    background: none !important;
+    background-color: #27956c !important;
+    border: 1px solid #000 !important;
+}
 
 #nav {
-	display:inline-block;
-	margin-left: 30px;
-	margin-right: 30px;
+    display:inline-block;
+    margin-left: 30px;
+    margin-right: 30px;
 }
 
-.slider_controls{
-	bottom:46px;
-	position:relative;
-	width: 217px;
-	right: 8px;
+.slider_controls {
+    bottom: 46px;
+    position: relative;
+    width: 217px;
+    right: 8px;
 }
 
-.scb_s_experiment_setup_create_new_set_up{
-	cursor: pointer;
-	font-size: 14px !important;
+.scb_s_experiment_setup_create_new_set_up {
+    cursor: pointer;
+    font-size: 14px !important;
 }
 
-
-.slider_controls > button{
-
-	padding:3px !important;
-	margin:0px !important;
-	margin-right:-5px !important;
-	margin-left:-5px !important;
-	padding-bottom: 4px !important;
-	border:inherit !important;
-	background: 0 !important;
-	cursor:pointer !important;
-	color: #29a592 !important;
+.slider_controls > button {
+    padding: 3px !important;
+    margin: 0px !important;
+    margin-right: -5px !important;
+    margin-left: -5px !important;
+    padding-bottom: 4px !important;
+    border:inherit !important;
+    background: 0 !important;
+    cursor:pointer !important;
+    color: #29a592 !important;
 }
 
 .swipe {
@@ -266,68 +258,71 @@ nav ul li.on{
   position: relative;
   background:0 !important;
 }
+
 .swipe-wrap {
   overflow: hidden;
   position: relative;
 }
+
 .swipe-wrap > div {
-  float:left;
-  width:100%;
+  float: left;
+  width: 100%;
   position: relative;
 }
+
 .scb_s_warning_dialog {
     background: #f5f5f5;
-	overflow: visible;
-	width: 560px;
-	height: 225px;
+    overflow: visible;
+    width: 560px;
+    height: 225px;
     border-radius: 14px;
-	font-family: sourcesanspro-regular;
-	font-weight: normal !important;
+    font-family: sourcesanspro-regular;
+    font-weight: normal !important;
 }
 
-.scb_s_warning>h1{
-    color:red;
+.scb_s_warning > h1 {
+    color: red;
 }
 
 .jqDialog_header {
-	background: #27956c;
-	color: white;
-	padding: 10px;
-	height: 25px;
-	position: relative;
-	font-family: 'sourcesanspro-semibold';
-	border-top-left-radius: 9px;
-	border-top-right-radius: 9px;
-	font-size: 13pt;
-	letter-spacing: .5px;
-	right: 0px;
-	bottom: 10px;
+    background: #27956c;
+    color: white;
+    padding: 10px;
+    height: 25px;
+    position: relative;
+    font-family: 'sourcesanspro-semibold';
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    font-size: 13pt;
+    letter-spacing: .5px;
+    right: 0px;
+    bottom: 10px;
 }
 
 .jqDialog_confirm_header {
-	background: #27956c;
-	color: white;
-	padding: 10px;
-	height: 25px;
-	position: relative;
-	width: 548px;
-	font-family: 'sourcesanspro-semibold';
-	border-top-left-radius: 9px;
-	border-top-right-radius: 9px;
-	font-size: 13pt;
-	letter-spacing: .5px;
-	right: 3px;
-	bottom: 16px;
+    background: #27956c;
+    color: white;
+    padding: 10px;
+    height: 25px;
+    position: relative;
+    width: 548px;
+    font-family: 'sourcesanspro-semibold';
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    font-size: 13pt;
+    letter-spacing: .5px;
+    right: 3px;
+    bottom: 16px;
 }
 
-.scb_s_experiment_setup_radio_text{
-position: absolute;
-top: 2px;
+.scb_s_experiment_setup_radio_text {
+    position: absolute;
+    top: 2px;
 }
 
 .scb_s_experiment_setup_table_heading {
     font-family: 'sourcesanspro-semibold';
-    font-size:10pt;
+    font-size: 10pt;
     width: 127px;
     text-align: left;
 }
@@ -344,33 +339,31 @@ top: 2px;
     margin-right: 1em;
 }
 
-
-.scb_s_experiment_setup_choose_template > input{
-	-webkit-appearance: none;
-	height:13px;
-	width:12px;
-	border: 1px solid #C0C0C0;
-	background-color:#D0D0D0;
-	border-radius:6px;
-	margin-bottom: -0.125%;
+.scb_s_experiment_setup_choose_template > input {
+    -webkit-appearance: none;
+    height: 13px;
+    width: 12px;
+    border: 1px solid #C0C0C0;
+    background-color: #D0D0D0;
+    border-radius: 6px;
+    margin-bottom: -0.125%;
 }
 
-
-.scb_s_experiment_setup_choose_template > input:checked{
-	-webkit-appearance: none;
-	height:13px;
-	width:12px;
-	border: 1px solid #000000;
-	background-color:white;
-	border-radius:6px;
-	margin-bottom: -0.125%;
+.scb_s_experiment_setup_choose_template > input:checked {
+    -webkit-appearance: none;
+    height: 13px;
+    width: 12px;
+    border: 1px solid #000000;
+    background-color: white;
+    border-radius: 6px;
+    margin-bottom: -0.125%;
 }
 
 .scb_concentration_edit_new {
-    position:absolute;
-    float:left;
-    width:80px;
-    height:24px;
+    position: absolute;
+    float: left;
+    width: 80px;
+    height: 24px;
 }
 
 .scb_s_experiment_setup_table_row:hover {
@@ -381,38 +374,36 @@ top: 2px;
     opacity: 1;
 }
 
-.overlay{
-	width: 100%;
-	height: 100%;
-	position: fixed;
-	z-index: 993; 
-	background: rgba(125,125,125,0.7);
-	visibility: visible;
-	right: 0px;
-	top: 0px;
+.overlay {
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    z-index: 993;
+    background: rgba(125,125,125,0.7);
+    visibility: visible;
+    right: 0px;
+    top: 0px;
 }
 
-
-.error_overlay{
-	width: 100%;
-	height: 100%;
-	position: fixed;
-	z-index: 993; 
-	background: rgba(0,0,0,0);
-	visibility: visible;
-	right: 0px;
-	top: 0px;
+.error_overlay {
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    z-index: 993;
+    background: rgba(0,0,0,0);
+    visibility: visible;
+    right: 0px;
+    top: 0px;
 }
-
 
 .scb_s_experiment_setup_table_element[kind="cell_plate"] {
-    width:60px;
+    width: 60px;
     max-width: 60px;
     min-width: 60px;
 }
 
 .scb_s_experiment_setup_table_element {
-    width:120px;
+    width: 120px;
 }
 
 .scb_f_experiment_setup_action_open_add_samples_dialog {
@@ -420,8 +411,8 @@ top: 2px;
 }
 
 .scb_s_experiment_design_green_line {
-    width:100%;
-    height:2px;
+    width: 100%;
+    height: 2px;
     background-color: #27956c;
-    margin-bottom:2px;
+    margin-bottom: 2px;
 }

--- a/html_app/ui/experiment_setup.gss
+++ b/html_app/ui/experiment_setup.gss
@@ -291,12 +291,12 @@ nav ul li.on {
     height: 25px;
     position: relative;
     font-family: 'sourcesanspro-semibold';
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
     font-size: 13pt;
     letter-spacing: .5px;
     right: 0px;
-    bottom: 10px;
+    bottom: 11px;
 }
 
 .jqDialog_confirm_header {

--- a/html_app/ui/experiment_setup.gss
+++ b/html_app/ui/experiment_setup.gss
@@ -53,8 +53,10 @@
 }
 
 .scb_s_warning_dialog>.scb_f_open_experiment_setup {
-    top: -12px;
-    right: 203px !important;
+    top: 3px;
+    float: left;
+    position: relative;
+    left: 50px;
 }
 
 .scb_s_select_technique_container>.scb_f_open_experiment_setup_readonly {
@@ -78,8 +80,8 @@
 }
 
 .scb_s_warning_dialog>.scb_f_open_select_technique {
+    top: -12px;
     float: right;
-    top: 2px;
     position: relative;
     right: 50px;
 }
@@ -274,7 +276,6 @@ nav ul li.on {
     background: #f5f5f5;
     overflow: visible;
     width: 560px;
-    height: 225px;
     border-radius: 14px;
     font-family: sourcesanspro-regular;
     font-weight: normal !important;
@@ -305,14 +306,14 @@ nav ul li.on {
     padding: 10px;
     height: 25px;
     position: relative;
-    width: 548px;
+    width: 536px;
     font-family: 'sourcesanspro-semibold';
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
     font-size: 13pt;
     letter-spacing: .5px;
-    right: 3px;
-    bottom: 16px;
+    left: 2px;
+    bottom: 10px;
 }
 
 .scb_s_experiment_setup_radio_text {

--- a/html_app/ui/experiment_setup.soy
+++ b/html_app/ui/experiment_setup.soy
@@ -495,6 +495,14 @@ Experiment active area
     </p>
     <a
         role='button'
+        aria-label='Edit Set Up'
+        class='scb_s_navigation_button scb_f_open_experiment_setup'
+        href='#view=experiment_setup&experiment_id={$experiment.id}&assignment_id={$assignment.id}'>
+        &#9664; &nbsp; EDIT SET-UP
+    </a>
+    <br>
+    <a
+        role='button'
         aria-label='Confirm Set Up and Run'
         class='scb_s_navigation_button scb_f_open_select_technique'
         href='#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}'
@@ -502,14 +510,6 @@ Experiment active area
         experiment_id='{$experiment.id}'>
         CONFIRM SET-UP & RUN &nbsp; &#9654;
     </a>
-    <br>
-    <span
-        role='button'
-        aria-label='Edit Set Up'
-        class='scb_s_navigation_button scb_f_open_experiment_setup'
-        href='#view=experiment_setup&experiment_id={$experiment.id}&assignment_id={$assignment.id}'>
-        &#9664; &nbsp; EDIT SET-UP
-    </span>
 </div>
 {/template}
 

--- a/html_app/ui/experiment_setup.soy
+++ b/html_app/ui/experiment_setup.soy
@@ -308,23 +308,25 @@ Experiment active area
     
 </div>
 {if $kind == 'readwrite'}
-    <a class="scb_s_navigation_button scb_f_open_experiment_setup_readonly scb_f_run_experiment" aria-label='Run Experiment' role='button'
-       href="#view=experiment_run&assignment_id={$assignment.id}&experiment_id={$experiment.id}" assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'>RUN EXPERIMENT &nbsp; &#9654;</a><br/>
     <a class="scb_s_navigation_button scb_f_open_experiment_design" aria-label='Design Experiment' role='button'
        href="#view=experiment_design&experiment_id={$experiment.id}&assignment_id={$assignment.id}">&#9664; &nbsp; DESIGN EXPERIMENT
-        </a>
-    {else}
+    </a>
+    <br/>
+    <a class="scb_s_navigation_button scb_f_open_experiment_setup_readonly scb_f_run_experiment" aria-label='Run Experiment' role='button'
+       href="#view=experiment_run&assignment_id={$assignment.id}&experiment_id={$experiment.id}" assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'>RUN EXPERIMENT &nbsp; &#9654;
+    </a>
+{else}
     {if $experiment.setup_finished}
-    <a class="scb_s_navigation_button scb_f_open_select_technique"
-       href="#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}" aria-label='Select Technique' role='button'
-       assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'>SELECT TECHNIQUE &nbsp; &#9654;</a><br/>
-    <a class="scb_s_navigation_button scb_f_open_experiment_design" role='button' aria-label='Design Experiment' 
-       href="#view=experiment_design&experiment_id={$experiment.id}&assignment_id={$assignment.id}">&#9664; &nbsp; DESIGN EXPERIMENT
-        </a>
-    {else}
+	    <a class="scb_s_navigation_button scb_f_open_experiment_design" role='button' aria-label='Design Experiment' 
+	       href="#view=experiment_design&experiment_id={$experiment.id}&assignment_id={$assignment.id}">&#9664; &nbsp; DESIGN EXPERIMENT
+	    </a>
+	    <br/>
+	    <a class="scb_s_navigation_button scb_f_open_select_technique"
+	       href="#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}" aria-label='Select Technique' role='button'
+	       assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'>SELECT TECHNIQUE &nbsp; &#9654;
+	    </a>
     {/if}
-
-    {/if}
+{/if}
 </div>
 
 </div>

--- a/html_app/ui/experiment_setup.soy
+++ b/html_app/ui/experiment_setup.soy
@@ -14,8 +14,8 @@
 {template .main}
 <div class='scb_s_experiment_setup_view' >
     {call scb_homepage.display_header}
-    {param global_template:$global_template /}
-    {param context:$context /}
+        {param global_template:$global_template /}
+        {param context:$context /}
     {/call}
     {call scb_common.assignment_step}
         {param step:4/}
@@ -27,15 +27,15 @@
         {param experiment:$experiment/}
     {/call}
     {call .display_details}
-    {param t:$t/}
-    {param last_step: $last_step/}
-    {param global_template:$global_template /}
-    {param assignment:$assignment/}
-    {param new_rows:$new_rows/}
+        {param t:$t/}
+        {param last_step: $last_step/}
+        {param global_template:$global_template /}
+        {param assignment:$assignment/}
+        {param new_rows:$new_rows/}
     {/call}
     {call scb_homepage.display_footer}
-    {param global_template:$t /}
-    {param assignment:$assignment/}
+        {param global_template:$t /}
+        {param assignment:$assignment/}
     {/call}
 </div>
 {/template}
@@ -52,281 +52,299 @@ Experiment active area
 @param new_rows
 */
 {template .display_details}
-	
 <div class='scb_s_experiment_setup_container' role='main'>
-<div class='scb_s_experiment_setup_details_view' mode='{$kind}'>
+    <div class='scb_s_experiment_setup_details_view' mode='{$kind}'>
+        {if $kind == 'readwrite'}
+            {call scb_common.experiment_step}
+                {param step:2/}
+                {param last_step: $last_step/}
+                {param assignment: $assignment/}
+                {param experiment: $experiment/}
 
-    
-
-    {if $kind == 'readwrite'}
-        {call scb_common.experiment_step}
-            {param step:2/}
-            {param last_step: $last_step/}
-            {param assignment: $assignment/}
-            {param experiment: $experiment/}
-
-        {/call}
-    	<div class='scb_s_experiment_setup_top'>
-        <div class='scb_s_experiment_setup_choose_template'>
-<!-- 
-            <div class='scb_s_experiment_setup_create_new_set_up' assignment_id='{$assignment.id}' experiment_id='{$experiment.id}' aria-label='Create New Set-up' role='radio'><input class='scb_s_experiment_setup_choose_template_kind scb_f_experiment_setup_new_set_up' type="radio" name="setup_kind"/><span class='scb_s_experiment_setup_radio_text' role='presentation'>Create new set-up</span><br></div>
- -->
-<!-- <div class='scb_s_experiment_setup_choose_existing_template'><input class='scb_s_experiment_setup_choose_template_kind' type="radio" name="setup_kind" disabled="disabled" /><span class='scb_s_experiment_setup_choose_template_kind_disabled'>Select pre-existing set-up as a template</span></div>-->
-
-            <br>
-        </div>
-        <!--
-        <div class='scb_s_experiment_setup_video_box_wrapper'  alt='Video Player Background'  aria-label='Video Player Background'>
-            <div class='scb_s_experiment_setup_video_box_wrapper_title'  role='presentation' >
-                IN THE LAB
-            </div>
-            <div class='scb_s_experiment_setup_video_box_placeholder' role='presentation' >
-						</div>
-				
-				
-			<div class='scb_s_experiment_setup_video_text' role='presentation' >
-			</div>           
-		</div>
-		-->
-    {else}
-        {call scb_common.experiment_step}
-            {param step:3/}
-            {param last_step: $last_step/}
-            {param assignment: $assignment/}
-            {param experiment: $experiment/}
-        {/call}
-        <div class='scb_s_experiment_setup_top'>
-        {if $experiment.setup_finished}
-        <div class='scb_s_warning' role='note'>
-
-        <h1>NOTE!</h1>
-        <p>Below is a summary of your set-up for {$experiment.name}.<br>
-            To create a new experiment, select <b>+ New Experiment</b> next to <b>{$assignment.name}: {$experiment.name}</b> 
-            drop down menu above the navigation tool bar.
-            <br>
-            <br>
-
-        </p>
-        </div>
+            {/call}
+            <div class='scb_s_experiment_setup_top'>
+                <div class='scb_s_experiment_setup_choose_template'>
+                    <br>
+                </div>
         {else}
-			<div class='scb_s_warning_dialog' role='alert'>
-            <h1>CONFIRM SET-UP</h1>
-            <p>Below is your set-up for '{$experiment.name}'.<br>
-            
-            Once you run this experiment, you cannot go back and make changes to this experiment's set-up.
-             Review the summary of your experimental set-up and then either go back to edit your set-up or click on <b>Confirm Set-Up & Run</b> to run your experiment.
-
-            </p>
-			
-			<a class="scb_s_navigation_button scb_f_open_select_technique"
-			   href="#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}"
-			   assignment_id='{$assignment.id}' experiment_id='{$experiment.id}' aria-label='Select Technique' role='button' >SELECT TECHNIQUE &nbsp; &#9654;</a><br/>
-			<a class="scb_s_navigation_button scb_f_open_experiment_setup"
-			   href="#view=experiment_setup&experiment_id={$experiment.id}&assignment_id={$assignment.id}" aria-label='Edit Set-Up' role='button'>&#9664; &nbsp; EDIT SET-UP
-				</a>
-				</div>
-        {/if}
- 		<div class='scb_s_experiment_setup_video_box_wrapper' alt='Video Player Background'  aria-label='Video Player Background'>
-            <div class='scb_s_experiment_setup_video_box_wrapper_title' role='presentation' >
-                IN THE LAB
-            </div>
-            <div class='scb_s_experiment_setup_video_box_placeholder' role='presentation' >
-						</div>
-				
-				
-			<div class='scb_s_experiment_setup_video_text' role='presentation' >
-			</div>           
-		</div>
-
-    {/if}
-    </div>
-    <div class="scb_s_experiment_setup_new_set_up">
-        <div class="scb_s_experiment_setup_instructions" aria-label='Setup Instructions' role='textbox'>
-            {if $t.experiment_setup}
-                {$t.experiment_setup|noAutoescape}
-            {else}
-                <ul role='list' class='scb_assignment_specific_tufts_experiment_setup'>
-                    <li role='listitem'>
-                        To setup your experiment, select <b role='presentation' >Add Samples </b>
-                        in the experimental set-up table below. <br>
-                    </li>
-                    <li  role='listitem'>
-                        Select all of the treatment protocols for your experiment within the
-                        <b role='presentation'> Add Samples</b> pop up window, and
-                        then click <b role='presentation'>Add Samples</b>.
-                    </li>
-                </ul>
+            {call scb_common.experiment_step}
+                {param step:3/}
+                {param last_step: $last_step/}
+                {param assignment: $assignment/}
+                {param experiment: $experiment/}
+            {/call}
+            <div class='scb_s_experiment_setup_top'>
+                {if $experiment.setup_finished}
+                    <div class='scb_s_warning' role='note'>
+                        <h1>NOTE!</h1>
+                        <p>
+                            Below is a summary of your set-up for {$experiment.name}.
+                            <br>
+                            To create a new experiment, select <b>+ New Experiment</b> next to <b>{$assignment.name}: {$experiment.name}</b>
+                            drop down menu above the navigation tool bar.
+                            <br>
+                            <br>
+                        </p>
+                    </div>
+                {else}
+                    <div class='scb_s_warning_dialog' role='alert'>
+                        <h1>CONFIRM SET-UP</h1>
+                        <p>
+                            Below is your set-up for '{$experiment.name}'.
+                            <br>
+                            Once you run this experiment, you cannot go back and make changes to this experiment's set-up.
+                            Review the summary of your experimental set-up and then either go back to edit your set-up or click on <b>Confirm Set-Up & Run</b> to run your experiment.
+                        </p>
+                        <a
+                           class="scb_s_navigation_button scb_f_open_select_technique"
+                           href="#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}"
+                           assignment_id='{$assignment.id}'
+                           experiment_id='{$experiment.id}'
+                           aria-label='Select Technique'
+                           role='button'>
+                           SELECT TECHNIQUE &nbsp; &#9654;
+                        </a>
+                        <br>
+                        <a class="scb_s_navigation_button scb_f_open_experiment_setup"
+                           href="#view=experiment_setup&experiment_id={$experiment.id}&assignment_id={$assignment.id}"
+                           aria-label='Edit Set-Up'
+                           role='button'>
+                           &#9664; &nbsp; EDIT SET-UP
+                        </a>
+                    </div>
+                {/if}
+                <div class='scb_s_experiment_setup_video_box_wrapper' alt='Video Player Background'  aria-label='Video Player Background'>
+                    <div class='scb_s_experiment_setup_video_box_wrapper_title' role='presentation'>
+                        IN THE LAB
+                    </div>
+                    <div class='scb_s_experiment_setup_video_box_placeholder' role='presentation'></div>
+                    <div class='scb_s_experiment_setup_video_text' role='presentation'></div>
+                </div>
             {/if}
         </div>
-        <br>
-		<table class="scb_s_experiment_setup_table 
-		{if $kind == 'readwrite'} scb_s_experiment_setup_table_editable{else} scb_s_experiment_setup_table_readonly{/if}"
-		 aria-label='Table of Samples' role='grid'>
-			<thead class='scb_s_experiment_setup_table_head' >
-			{foreach $h in $headings}
-				<td role='columnheader' aria-label='{$h.title}' class='scb_s_experiment_setup_table_heading' kind='{$h.kind}'>
-
-					{if $kind == 'readonly'}
-						{if $h.kind != 'actions'}
-							{$h.title}
-						{/if}
-					{else}
-					{$h.title}
-
-					{/if}
-
-				</td>
-			{/foreach}
-			</thead>
-			<tbody class='scb_s_experiment_setup_table_body'>
-			{foreach $r in $rows}
-			<tr class='scb_s_experiment_setup_table_row' role='row' aria-label='Sample' cell_treatment_id='{$r.id}' assignment_id='{$assignment.id}' experiment_id='{$experiment.id}' treatment_id='{$r.treatment.id}'>
-				{foreach $c in $r.columns}
-				<td class='scb_s_experiment_setup_table_element {if $c.first_row}scb_s_experiment_setup_table_border{/if}' kind='{$c.kind}' rowspan="{$c.rows}">
-					{if $c.kind == 'actions'}
-						{if $kind == 'readwrite'}
-						{if $assignment.id == 'assignment_706_2014'}
-						{else}
-						<button role='button' aria-label='Copy'  class='scb_f_experiment_setup_duplicate_sample' cell_treatment_id='{$r.id}'
-								assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'><img alt="" title="Copy" role='presentation' src="images/setup/scb_copy.png">
-						</button>
-						{/if}
-						<button role='button' aria-label='Delete'  class='scb_f_experiment_setup_remove_sample' cell_treatment_id='{$r.id}'
-							assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'><img alt="" title="Delete" role='presentation' src="images/setup/scb_remove.png">
-						</button>
-
-						{/if}
-					{else}
-						{if $c.kind=='cell_plate'}
-							<img src="images/setup/scb_cell_plate.png" role='presentation'>
-						{/if}
-						{if $c.kind =='collection' and $c.title =='default'}
-						{else}
-						{$c.title}
-						{/if}
-					{/if}
-				</td>
-				{/foreach}
-			</tr>
-			{/foreach}
-			{if $kind == 'readwrite'}
-			{foreach $r in $new_rows}
-			<tr role='row' aria-label='Sample' class='scb_s_experiment_setup_new_row scb_s_experiment_setup_new_row_gray' assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'>
-				{foreach $c in $r.columns}
-				<td style='z-index:99' class='scb_s_experiment_setup_table_element {if $c.first_row}scb_s_experiment_setup_table_border{/if} scb_s_experiment_setup_td' kind='{$c.kind}' rowspan="1">
-					{if $c.kind == 'actions'}
-						{if $kind == 'readwrite'} 
-						{/if}
-					{else}
-						{if $c.kind=='cell_plate'}
-							<img src="images/setup/scb_cell_plate.png" role='presentation' >
-						{/if}
-						{if $c.kind=='drug' and length(keys($t.drugs)) > 1}
-						<span>
-
-						 <span class='scb_concentration_edit_new'>
-							 &nbsp;
-						 </span>
-							{call .drug_edit }
-								{param template:$t/}
-								{param assignment:$assignment/}
-								{param experiment:$experiment/}
-								{param drug_id:$r.treatment.drug_list.list[0].drug_id/}
-								{param disabled:true/}
-							{/call}
-						</span>
-						{elseif $c.kind=='concentration' and length(keys($t.concentrations)) > 1 }
-						<span>
-							 <span class='scb_concentration_edit_new'>
-								 &nbsp;
-							 </span>
-							{call .concentration_edit}
-							{param template:$t/}
-							{param assignment:$assignment/}
-							{param experiment:$experiment/}
-							{param drug_id:$r.treatment.drug_list.list[0].drug_id/}
-							{param concentration_id:$r.treatment.drug_list.list[0].concentration_id/}
-							{param concentrations: $t.drugs[$r.treatment.drug_list.list[0].drug_id].concentrations/}
-							{param disabled:true/}
-							{/call}
-						</span>
-						{elseif $c.kind=='cell_line' and length(keys($t.cell_lines)) > 1 }
-						<span>
-
-						 <span class='scb_concentration_edit_new'>
-							 &nbsp;
-						 </span>
-							{call .cell_lines_edit}
-								{param template:$t/}
-								{param assignment:$assignment/}
-								{param experiment:$experiment/}
-								{param cell_line_id:$t.cell_lines['p+']/}
-								{param disabled:true/}
-							{/call}
-						</span>
-						{elseif $c.kind=='collection' and length(keys($t.collections)) > 1 }
-						<span>
-
-						 <span class='scb_concentration_edit_new'>
-							 &nbsp;
-						 </span>
-							{call .collection_edit}
-								{param template:$t/}
-								{param assignment:$assignment/}
-								{param experiment:$experiment/}
-								{param collection_id:$t.collections['3 m']/}
-								{param disabled:true/}
-							{/call}
-						</span>
-						{else}
-						{$c.title}
-						{/if}
-					{/if}
-				</td>
-				{/foreach}
-			</tr>
-			{/foreach}
-				{if $t.ui.experiment_setup.actions.length > 0}
-			<tr role='row' >
-				<td colspan="{$headings.length+1}">
-					<div class='scb_s_experiment_design_green_line' role='presentation'></div>
-					<button class='scb_f_experiment_setup_action_open_add_samples_dialog scb_s_gray_button' role='button' aria-label='{$t.ui.experiment_setup.actions[0].name}' assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'>{$t.ui.experiment_setup.actions[0].name}</button>
-				</td>
-			</tr>
-				{/if}
-			{/if}
-			</tbody>
-		</table>
-	</div>
-    {if $t.experiment_setup_actions}
-    {call .display_add_sample_dialog}
-    {param t:$t /}
-    {param assignment:$assignment /}
-    {param experiment:$experiment /}
-    {/call}
+        <div class="scb_s_experiment_setup_new_set_up">
+            <div class="scb_s_experiment_setup_instructions" aria-label='Setup Instructions' role='textbox'>
+                {if $t.experiment_setup}
+                    {$t.experiment_setup|noAutoescape}
+                {else}
+                    <ul role='list' class='scb_assignment_specific_tufts_experiment_setup'>
+                        <li role='listitem'>
+                            To setup your experiment, select <b role='presentation' >Add Samples </b>
+                            in the experimental set-up table below. <br>
+                        </li>
+                        <li  role='listitem'>
+                            Select all of the treatment protocols for your experiment within the
+                            <b role='presentation'> Add Samples</b> pop up window, and
+                            then click <b role='presentation'>Add Samples</b>.
+                        </li>
+                    </ul>
+                {/if}
+            </div>
+            <br>
+            <table
+                class="scb_s_experiment_setup_table {if $kind == 'readwrite'} scb_s_experiment_setup_table_editable{else} scb_s_experiment_setup_table_readonly{/if}"
+                aria-label='Table of Samples'
+                role='grid'>
+                <thead class='scb_s_experiment_setup_table_head'>
+                    {foreach $h in $headings}
+                        <td role='columnheader' aria-label='{$h.title}' class='scb_s_experiment_setup_table_heading' kind='{$h.kind}'>
+                            {if $kind == 'readonly'}
+                                {if $h.kind != 'actions'}
+                                    {$h.title}
+                                {/if}
+                            {else}
+                                {$h.title}
+                            {/if}
+                        </td>
+                    {/foreach}
+                </thead>
+                <tbody class='scb_s_experiment_setup_table_body'>
+                    {foreach $r in $rows}
+                        <tr
+                            class='scb_s_experiment_setup_table_row'
+                            role='row' aria-label='Sample'
+                            cell_treatment_id='{$r.id}'
+                            assignment_id='{$assignment.id}'
+                            experiment_id='{$experiment.id}'
+                            treatment_id='{$r.treatment.id}'>
+                            {foreach $c in $r.columns}
+                                <td
+                                    class='scb_s_experiment_setup_table_element {if $c.first_row}scb_s_experiment_setup_table_border{/if}'
+                                    kind='{$c.kind}'
+                                    rowspan="{$c.rows}">
+                                    {if $c.kind == 'actions'}
+                                        {if $kind == 'readwrite'}
+                                            {if $assignment.id == 'assignment_706_2014'}
+                                            {else}
+                                                <button
+                                                    role='button'
+                                                    aria-label='Copy'
+                                                    class='scb_f_experiment_setup_duplicate_sample'
+                                                    cell_treatment_id='{$r.id}'
+                                                    assignment_id='{$assignment.id}'
+                                                    experiment_id='{$experiment.id}'>
+                                                    <img alt="" title="Copy" role='presentation' src="images/setup/scb_copy.png">
+                                                </button>
+                                            {/if}
+                                            <button
+                                                role='button'
+                                                aria-label='Delete'
+                                                class='scb_f_experiment_setup_remove_sample'
+                                                cell_treatment_id='{$r.id}'
+                                                assignment_id='{$assignment.id}'
+                                                experiment_id='{$experiment.id}'>
+                                                <img alt="" title="Delete" role='presentation' src="images/setup/scb_remove.png">
+                                            </button>
+                                        {/if}
+                                    {else}
+                                        {if $c.kind=='cell_plate'}
+                                            <img src="images/setup/scb_cell_plate.png" role='presentation'>
+                                        {/if}
+                                        {if $c.kind =='collection' and $c.title =='default'}
+                                        {else}
+                                            {$c.title}
+                                        {/if}
+                                    {/if}
+                                </td>
+                            {/foreach}
+                        </tr>
+                    {/foreach}
+                    {if $kind == 'readwrite'}
+                        {foreach $r in $new_rows}
+                            <tr
+                                role='row'
+                                aria-label='Sample'
+                                class='scb_s_experiment_setup_new_row scb_s_experiment_setup_new_row_gray'
+                                assignment_id='{$assignment.id}'
+                                experiment_id='{$experiment.id}'>
+                                {foreach $c in $r.columns}
+                                    <td style='z-index:99' class='scb_s_experiment_setup_table_element {if $c.first_row}scb_s_experiment_setup_table_border{/if} scb_s_experiment_setup_td' kind='{$c.kind}' rowspan="1">
+                                        {if $c.kind == 'actions'}
+                                            {if $kind == 'readwrite'}
+                                            {/if}
+                                        {else}
+                                            {if $c.kind=='cell_plate'}
+                                                <img src="images/setup/scb_cell_plate.png" role='presentation'>
+                                            {/if}
+                                            {if $c.kind=='drug' and length(keys($t.drugs)) > 1}
+                                                <span>
+                                                    <span class='scb_concentration_edit_new'>&nbsp;</span>
+                                                    {call .drug_edit }
+                                                        {param template:$t/}
+                                                        {param assignment:$assignment/}
+                                                        {param experiment:$experiment/}
+                                                        {param drug_id:$r.treatment.drug_list.list[0].drug_id/}
+                                                        {param disabled:true/}
+                                                    {/call}
+                                                </span>
+                                            {elseif $c.kind=='concentration' and length(keys($t.concentrations)) > 1}
+                                                <span>
+                                                    <span class='scb_concentration_edit_new'>&nbsp;</span>
+                                                    {call .concentration_edit}
+                                                        {param template:$t/}
+                                                        {param assignment:$assignment/}
+                                                        {param experiment:$experiment/}
+                                                        {param drug_id:$r.treatment.drug_list.list[0].drug_id/}
+                                                        {param concentration_id:$r.treatment.drug_list.list[0].concentration_id/}
+                                                        {param concentrations: $t.drugs[$r.treatment.drug_list.list[0].drug_id].concentrations/}
+                                                        {param disabled:true/}
+                                                    {/call}
+                                                </span>
+                                            {elseif $c.kind=='cell_line' and length(keys($t.cell_lines)) > 1 }
+                                                <span>
+                                                    <span class='scb_concentration_edit_new'>&nbsp;</span>
+                                                    {call .cell_lines_edit}
+                                                        {param template:$t/}
+                                                        {param assignment:$assignment/}
+                                                        {param experiment:$experiment/}
+                                                        {param cell_line_id:$t.cell_lines['p+']/}
+                                                        {param disabled:true/}
+                                                    {/call}
+                                                </span>
+                                            {elseif $c.kind=='collection' and length(keys($t.collections)) > 1 }
+                                                <span>
+                                                    <span class='scb_concentration_edit_new'>&nbsp;</span>
+                                                    {call .collection_edit}
+                                                        {param template:$t/}
+                                                        {param assignment:$assignment/}
+                                                        {param experiment:$experiment/}
+                                                        {param collection_id:$t.collections['3 m']/}
+                                                        {param disabled:true/}
+                                                    {/call}
+                                                </span>
+                                            {else}
+                                                {$c.title}
+                                            {/if}
+                                        {/if}
+                                    </td>
+                                {/foreach}
+                            </tr>
+                        {/foreach}
+                        {if $t.ui.experiment_setup.actions.length > 0}
+                            <tr role='row' >
+                                <td colspan="{$headings.length+1}">
+                                    <div class='scb_s_experiment_design_green_line' role='presentation'></div>
+                                    <button
+                                        class='scb_f_experiment_setup_action_open_add_samples_dialog scb_s_gray_button'
+                                        role='button'
+                                        aria-label='{$t.ui.experiment_setup.actions[0].name}'
+                                        assignment_id='{$assignment.id}'
+                                        experiment_id='{$experiment.id}'>
+                                        {$t.ui.experiment_setup.actions[0].name}
+                                    </button>
+                                </td>
+                            </tr>
+                        {/if}
+                    {/if}
+                </tbody>
+            </table>
+        </div>
+        {if $t.experiment_setup_actions}
+            {call .display_add_sample_dialog}
+                {param t:$t /}
+                {param assignment:$assignment /}
+                {param experiment:$experiment /}
+            {/call}
+        {/if}
+    </div>
+    {if $kind == 'readwrite'}
+        <a
+            class="scb_s_navigation_button scb_f_open_experiment_design"
+            aria-label='Design Experiment'
+            role='button'
+            href="#view=experiment_design&experiment_id={$experiment.id}&assignment_id={$assignment.id}">
+            &#9664; &nbsp; DESIGN EXPERIMENT
+        </a>
+        <br/>
+        <a
+            class="scb_s_navigation_button scb_f_open_experiment_setup_readonly scb_f_run_experiment"
+            aria-label='Run Experiment'
+            role='button'
+            href="#view=experiment_run&assignment_id={$assignment.id}&experiment_id={$experiment.id}"
+            assignment_id='{$assignment.id}'
+            experiment_id='{$experiment.id}'>
+            RUN EXPERIMENT &nbsp; &#9654;
+        </a>
+    {else}
+        {if $experiment.setup_finished}
+            <a
+                class="scb_s_navigation_button scb_f_open_experiment_design"
+                role='button' aria-label='Design Experiment'
+                href="#view=experiment_design&experiment_id={$experiment.id}&assignment_id={$assignment.id}">
+                &#9664; &nbsp; DESIGN EXPERIMENT
+            </a>
+            <br>
+            <a
+                class="scb_s_navigation_button scb_f_open_select_technique"
+                href="#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}"
+                aria-label='Select Technique'
+                role='button'
+                assignment_id='{$assignment.id}'
+                experiment_id='{$experiment.id}'>
+                SELECT TECHNIQUE &nbsp; &#9654;
+            </a>
+        {/if}
     {/if}
-    
-</div>
-{if $kind == 'readwrite'}
-    <a class="scb_s_navigation_button scb_f_open_experiment_design" aria-label='Design Experiment' role='button'
-       href="#view=experiment_design&experiment_id={$experiment.id}&assignment_id={$assignment.id}">&#9664; &nbsp; DESIGN EXPERIMENT
-    </a>
-    <br/>
-    <a class="scb_s_navigation_button scb_f_open_experiment_setup_readonly scb_f_run_experiment" aria-label='Run Experiment' role='button'
-       href="#view=experiment_run&assignment_id={$assignment.id}&experiment_id={$experiment.id}" assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'>RUN EXPERIMENT &nbsp; &#9654;
-    </a>
-{else}
-    {if $experiment.setup_finished}
-	    <a class="scb_s_navigation_button scb_f_open_experiment_design" role='button' aria-label='Design Experiment' 
-	       href="#view=experiment_design&experiment_id={$experiment.id}&assignment_id={$assignment.id}">&#9664; &nbsp; DESIGN EXPERIMENT
-	    </a>
-	    <br/>
-	    <a class="scb_s_navigation_button scb_f_open_select_technique"
-	       href="#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}" aria-label='Select Technique' role='button'
-	       assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'>SELECT TECHNIQUE &nbsp; &#9654;
-	    </a>
-    {/if}
-{/if}
 </div>
 
 </div>
@@ -345,9 +363,9 @@ Experiment active area
         Choose Your Cell Line:
         <select  role='select' aria-label='Cell Strains' class='scb_s_experiment_setup_dialog_cell_lines_select' multiple='multiple'>
             {foreach $cell_line in $t.experiment_setup_actions.cell_lines}
-            <option role='option' class='scb_s_experiment_setup_dialog_cell_lines_select_option' value='{$cell_line.id}'>
-                {$cell_line.title}
-            </option>
+                <option role='option' class='scb_s_experiment_setup_dialog_cell_lines_select_option' value='{$cell_line.id}'>
+                    {$cell_line.title}
+                </option>
             {/foreach}
         </select>
     </div>
@@ -355,8 +373,8 @@ Experiment active area
         Choose Your Treatment Line<br>
         <select role='select' aria-label='Treatment Line' class='scb_s_experiment_setup_dialog_treatments_select' multiple='multiple'>
             {foreach $treat in $t.experiment_setup_actions.treatment_protocol_list}
-            <option role='option' class='scb_s_experiment_setup_dialog_treatments_select_option' value='{$treat.id}'>{$treat.title}
-            </option>
+                <option role='option' class='scb_s_experiment_setup_dialog_treatments_select_option' value='{$treat.id}'>{$treat.title}
+                </option>
             {/foreach}
         </select>
     </div>
@@ -364,15 +382,14 @@ Experiment active area
         Choose Your Treatment Line<br>
         <select role='select' aria-label='Treatment Line' class='scb_s_experiment_setup_dialog_collection_select' multiple='multiple'>
             {foreach $collect in $t.experiment_setup_actions.collection_schedule_list}
-            <option role='option' class='scb_s_experiment_setup_dialog_collection_select_option' value='{$collect.id}'>
-                {$collect.title}
-            </option>
+                <option role='option' class='scb_s_experiment_setup_dialog_collection_select_option' value='{$collect.id}'>
+                    {$collect.title}
+                </option>
             {/foreach}
         </select>
     </div>
     <button class='scb_f_experiment_setup_dialog_apply' role='button' aria-lable='Add Samples'>Add</button>
     <button class='scb_f_experiment_setup_dialog_cancel' role='button' aria-lable='Add Samples'>Cancel</button>
-
 </div>
 {/template}
 
@@ -387,12 +404,11 @@ Experiment active area
 {template .cell_lines_edit}
     <select role='select'  aria-label='Cell Strains' title='cell_line' size='1' row='0' class='scb_f_experiment_setup_cell_line_edit' {if $disabled}disabled='disabled'{/if}>
         <option role='option' value='' disabled="disabled">Please select</option>
-		{foreach $t in keys($template.cell_lines)}
-			<option role='option'  value='{$t}' {if $t==$cell_line_id}selected='selected'{/if}>{$template.cell_lines[$t].name}</option>
-		{/foreach}
-	</select>
+        {foreach $t in keys($template.cell_lines)}
+            <option role='option'  value='{$t}' {if $t==$cell_line_id}selected='selected'{/if}>{$template.cell_lines[$t].name}</option>
+        {/foreach}
+    </select>
 {/template}
-
 
 /**
 * Collection edit
@@ -405,12 +421,11 @@ Experiment active area
 {template .collection_edit}
     <select role='select'  aria-label='Collection Time'   title='collection' size='1' row='0' class='scb_f_experiment_setup_collection_edit' {if $disabled}disabled='disabled'{/if}>
         <option role='option' value='' disabled="disabled">Please select</option>
-		{foreach $t in keys($template.collections)}
-			<option role='option' value='{$t}' {if $t==$collection_id}selected='selected'{/if}>{$template.collections[$t].name}</option>
-		{/foreach}
-	</select>
+        {foreach $t in keys($template.collections)}
+            <option role='option' value='{$t}' {if $t==$collection_id}selected='selected'{/if}>{$template.collections[$t].name}</option>
+        {/foreach}
+    </select>
 {/template}
-
 
 /**
 * Drug Edit
@@ -423,10 +438,10 @@ Experiment active area
 {template .drug_edit}
     <select role='select'  aria-label='Drug' title='drug' size='1' row='0' class='scb_f_experiment_setup_drug_edit' {if $disabled}disabled='disabled'{/if}>
         <option role='option' value='' disabled="disabled">Please select</option>
-		{foreach $t in keys($template.drugs)}
-			<option role='option' value='{$t}' {if $t==$drug_id}selected='selected'{/if}>{$template.drugs[$t].name}</option>
-		{/foreach}
-	</select>
+        {foreach $t in keys($template.drugs)}
+            <option role='option' value='{$t}' {if $t==$drug_id}selected='selected'{/if}>{$template.drugs[$t].name}</option>
+        {/foreach}
+    </select>
 {/template}
 
 /**
@@ -442,11 +457,10 @@ Experiment active area
     <select role='select'  aria-label='Concentration'  title='concentration' size='1' row='0' class='scb_f_experiment_setup_concentration_edit' {if $disabled}disabled='disabled'{/if}>
         <option role='option' value=''>Please select</option>
         {foreach $t in $concentrations}
-	        <option role='option' value='{$t}' {if $t==$concentration_id}selected='true'{/if}>{$template.concentrations[$t].name}</option>
+            <option role='option' value='{$t}' {if $t==$concentration_id}selected='true'{/if}>{$template.concentrations[$t].name}</option>
         {/foreach}
     </select>
 {/template}
-
 
 /**
 * Temperature Edit
@@ -460,14 +474,10 @@ Experiment active area
     <select role='select'  aria-label='Temperature' title='temperature' size='1' row='0' class='scb_f_experiment_setup_temperature_edit' {if $disabled}disabled='disabled'{/if}>
         <option role='option' value='' disabled="disabled">Please select</option>
         {foreach $t in keys($template.experiment_temperatures)}
-	        <option role='option' value='{$t}' {if $t==$temperature}selected='true'{/if}>{$template.experiment_temperatures[$t].name}</option>
+            <option role='option' value='{$t}' {if $t==$temperature}selected='true'{/if}>{$template.experiment_temperatures[$t].name}</option>
         {/foreach}
     </select>
 {/template}
-
-
-
-
 
 /**
 * Experiment Setup Dialog
@@ -475,30 +485,39 @@ Experiment active area
 * @param experiment
 */
 {template .experiment_setup_dialog}
-<div class='scb_s_warning_dialog' role='alert'><p>
-<h1 class='jqDialog_confirm_header' role='heading'>Confirm Set-Up</h1>
-Once you confirm the set-up of this experiment and run it, you cannot go back to edit this experiment's set-up. 
-To go back and edit your set-up, 
-click <b>EDIT SET-UP</b>
-or click on <b>CONFIRM SET-UP AND RUN</b> to proceed.
-<br/> To create a new experiment set-up, select <b>New Experiment +</b> above the navigation tool bar.
-</p><a role='button' aria-label='Confirm Set Up and Run' class='scb_s_navigation_button scb_f_open_select_technique' 
-			href='#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}'
-			assignment_id='{$assignment.id}' 
-			experiment_id='{$experiment.id}'>CONFIRM SET-UP & RUN &nbsp; &#9654;</a><br/>
-<span role='button' aria-label='Edit Set Up' class='scb_s_navigation_button scb_f_open_experiment_setup' 
-href='#view=experiment_setup&experiment_id={$experiment.id}&assignment_id={$assignment.id}'>
-				&#9664; &nbsp; EDIT SET-UP</span></div>
-
+<div class='scb_s_warning_dialog' role='alert'>
+    <p>
+        <h1 class='jqDialog_confirm_header' role='heading'>Confirm Set-Up</h1>
+        Once you confirm the set-up of this experiment and run it, you cannot go back to edit this experiment's set-up.
+        To go back and edit your set-up, click <b>EDIT SET-UP</b> or click on <b>CONFIRM SET-UP AND RUN</b> to proceed.
+        <br>
+        To create a new experiment set-up, select <b>New Experiment +</b> above the navigation tool bar.
+    </p>
+    <a
+        role='button'
+        aria-label='Confirm Set Up and Run'
+        class='scb_s_navigation_button scb_f_open_select_technique'
+        href='#view=select_technique&assignment_id={$assignment.id}&experiment_id={$experiment.id}'
+        assignment_id='{$assignment.id}'
+        experiment_id='{$experiment.id}'>
+        CONFIRM SET-UP & RUN &nbsp; &#9654;
+    </a>
+    <br>
+    <span
+        role='button'
+        aria-label='Edit Set Up'
+        class='scb_s_navigation_button scb_f_open_experiment_setup'
+        href='#view=experiment_setup&experiment_id={$experiment.id}&assignment_id={$assignment.id}'>
+        &#9664; &nbsp; EDIT SET-UP
+    </span>
+</div>
 {/template}
-
 
 /**
 * Experiment Setup Overlay
 */
 {template .experiment_setup_overlay}
 <div class='overlay' role='presentation'></div>
-
 {/template}
 
 /**
@@ -506,7 +525,6 @@ href='#view=experiment_setup&experiment_id={$experiment.id}&assignment_id={$assi
 */
 {template .general_error_overlay}
 <div class='error_overlay' role='presentation'></div>
-
 {/template}
 
 /**
@@ -515,7 +533,6 @@ href='#view=experiment_setup&experiment_id={$experiment.id}&assignment_id={$assi
 {template .experiment_error}
 <h1 class='jqDialog_header' role='heading' >Error</h1>
 {/template}
-
 
 /**
 * Experiment Setup CONFIRM

--- a/html_app/ui/facs.soy
+++ b/html_app/ui/facs.soy
@@ -83,7 +83,7 @@ FACS Main View
         {/call}
         
 	{if $kind == 'sample_prep'}
-	<a class='scb_s_navigation_button scb_f_facs_prepare_lysates' facs_id='{$facs.id}'
+	<a class='scb_s_navigation_button scb_f_facs_prepare_lysates' href="#" facs_id='{$facs.id}'
 	   assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'
 	{if $can_prepare_lysate}{else}disabled='disabled'{/if}> PREPARE SAMPLES  &nbsp; &#9654;
 	</a>

--- a/html_app/ui/homepage.gss
+++ b/html_app/ui/homepage.gss
@@ -102,17 +102,17 @@
 
 .scb_s_logo {
     float: left;
-    padding: 15px;
-    display: block;
-    width:25%;
+    margin: 18px 0 0 18px;
+}
+
+.scb_s_logo > img {
+    vertical-align: middle;
 }
 
 .scb_s_header_tools {
-    float: rigth;
-    vertical-align: top;
-    display: block;
-    text-align: right;
-    margin-top: -10px;
+    display: inline-block;
+    float: right;
+    margin-top: 10px;
 }
 
 .scb_f_contact {
@@ -150,6 +150,7 @@
 
 .scb_f_login {
     cursor: pointer;
+    margin-right: 2px;
 }
 
 .scb_s_header_tools_text {
@@ -189,11 +190,6 @@
     width: 150px;
     bottom: 27px;
     position: absolute;
-}
-
-.scb_s_logo_h1 {
-    display:inline;
-    font-size: 0px;
 }
 
 .scb_f_login {

--- a/html_app/ui/homepage.gss
+++ b/html_app/ui/homepage.gss
@@ -78,7 +78,7 @@
 }
 
 #jqDialog_options button{
-	outline: none !important;
+    outline: none !important;
 }
 
 .scb_s_homepage_view {
@@ -101,7 +101,7 @@
     display: block;
     width: inherit;
     height: 8px;
-	background: #27956c;
+    background: #27956c;
 }
 
 .scb_s_logo {
@@ -170,29 +170,29 @@
 }
 
 .scb_s_pencil_icon {
-	margin-left: 5px;
+    margin-left: 5px;
 }
 
 .scb_s_pencil_text {
-	margin-right:5px;
+    margin-right:5px;
 }
 
 .scb_s_homepage_see_more_button {
-	cursor: pointer;
+    cursor: pointer;
 }
 
 .scb_s_homepage_new_experiment {
-	left: 750px;
-	width: 150px;
-	bottom: 18px;
-	position: absolute;
+    left: 750px;
+    width: 150px;
+    bottom: 18px;
+    position: absolute;
 }
 
 .scb_s_new_assignments_experiment {
-	left: 750px;
-	width: 150px;
-	bottom: 27px;
-	position: absolute;
+    left: 750px;
+    width: 150px;
+    bottom: 27px;
+    position: absolute;
 }
 
 .scb_s_logo_h1 {
@@ -200,24 +200,24 @@
     font-size: 0px;
 }
 
-.scb_f_login{
-	width: 80px;
-	height: 15px;
-	font-size: 20px;
-	position: relative;
-	bottom: 6px;
-	font-family: 'sourcesanspro-semibold';
-	color: #316f94;
+.scb_f_login {
+    width: 80px;
+    height: 15px;
+    font-size: 20px;
+    position: relative;
+    bottom: 6px;
+    font-family: 'sourcesanspro-semibold';
+    color: #316f94;
 }
 
 .scb_s_homepage_content {
-	margin-top: 12px;
-	margin-left: 20px;
+    margin-top: 12px;
+    margin-left: 20px;
 }
 
-.scb_s_new_homepage_experiment{
-	position: relative;
-	bottom: 10px;
+.scb_s_new_homepage_experiment {
+    position: relative;
+    bottom: 10px;
 }
 
 .scb_s_header_vertical_line {
@@ -310,7 +310,6 @@
     font-size: 10pt;
     margin-top: 4px;
 }
-
 
 .scb_s_homepage_bottom {
     display: block;
@@ -412,7 +411,6 @@
 
 .scb_s_homepage_experimental_design_item {
     display: inline-block;
-
 }
 
 .scb_s_homepage_experimental_design_bullet_item_selected {
@@ -421,20 +419,21 @@
 }
 
 .scb_s_homepage_learn_more {
-    /*    display:block;
-        background: transparent;
-        border-width: 0px;
-        background-image: url('../images/homepage/learn_more_button.png');
-        background-size: 120px 33px;
-        background-position: center;
-        height: 33px;
-        width: 120px;
-        margin-top:18px;
-        margin-left: 178px;
-        font-family: 'sourcesanspro-semibold';
-        color: white;
-        font-size: 11pt;
-        */
+    /*
+    display:block;
+    background: transparent;
+    border-width: 0px;
+    background-image: url('../images/homepage/learn_more_button.png');
+    background-size: 120px 33px;
+    background-position: center;
+    height: 33px;
+    width: 120px;
+    margin-top:18px;
+    margin-left: 178px;
+    font-family: 'sourcesanspro-semibold';
+    color: white;
+    font-size: 11pt;
+    */
     position: absolute;
     top: 143px;
     left: 165px;
@@ -529,7 +528,7 @@
     width: 962px;
     background-color: #d5dce4;
     display: block;
-	box-shadow: 0 9px 9px -2px #939aa3 inset;
+    box-shadow: 0 9px 9px -2px #939aa3 inset;
     position:relative;
     z-index: 0;
 }
@@ -574,20 +573,20 @@ a {
 }
 
 .scb_s_homepage_top_left_text {
-	color: black;
-	font-size: 11pt;
-	display:block;
-	padding:15px;
-	position: relative;
-	top:50px;
-	left:20px;
-	width:215px;
-	background:rgba(255, 255, 255, 0.8);
-	line-height:18pt;
+    color: black;
+    font-size: 11pt;
+    display:block;
+    padding:15px;
+    position: relative;
+    top:50px;
+    left:20px;
+    width:215px;
+    background:rgba(255, 255, 255, 0.8);
+    line-height:18pt;
 }
 
 .scb_s_homepage_top_left_text b {
-	font-size: 14pt;
+    font-size: 14pt;
 }
 
 .scb_f_try_an_experiment {

--- a/html_app/ui/homepage.gss
+++ b/html_app/ui/homepage.gss
@@ -393,24 +393,24 @@
 
 .scb_s_homepage_experimental_design_bullet_item {
     display: block;
+    border: none;
+    width: 145px;
+    text-align: left;
+    background: transparent;
+    color: black;
     font-family: 'sourcesanspro-bold';
     font-size: 10pt;
     vertical-align: top;
     margin-left: 10px;
     padding-top: 2px;
     padding-bottom: 3.25px;
-    padding-left: 8px;
+    padding-left: 4px;
     cursor: pointer;
 }
 
 .scb_s_homepage_experimental_design_bullet {
     display: inline-block;
-    color: black;
     margin-right: 5px;
-}
-
-.scb_s_homepage_experimental_design_item {
-    display: inline-block;
 }
 
 .scb_s_homepage_experimental_design_bullet_item_selected {

--- a/html_app/ui/homepage.gss
+++ b/html_app/ui/homepage.gss
@@ -109,6 +109,25 @@
     vertical-align: middle;
 }
 
+.scb_s_skip_links {
+    display: inline-block;
+    height: 72px;
+    line-height: 72px;
+    cursor: default;
+}
+
+.scb_s_skip_to_sidebar, .scb_s_skip_to_content {
+    color: #f4f6f8;
+    margin-left: 10px;
+    vertical-align: middle;
+    pointer-events: none;
+}
+
+.scb_s_skip_to_sidebar:focus, .scb_s_skip_to_content:focus {
+    color: black;
+    pointer-events: inherit;
+}
+
 .scb_s_header_tools {
     display: inline-block;
     float: right;

--- a/html_app/ui/homepage.gss
+++ b/html_app/ui/homepage.gss
@@ -73,10 +73,6 @@
     src: url("../fonts/SourceSansPro-SemiboldIt.otf") format("opentype");
 }
 
-*:focus {
-    outline: 2px solid #1c1c1c;
-}
-
 #jqDialog_options button{
     outline: none !important;
 }

--- a/html_app/ui/homepage.gss
+++ b/html_app/ui/homepage.gss
@@ -525,18 +525,23 @@
     z-index: 0;
 }
 
+.scb_s_homepage_footer_logo {
+    float: left;
+    padding: 2px;
+}
+
 .scb_s_homepage_footer_divider {
     padding-left: 7px;
     padding-right: 7px;
     vertical-align: top;
-    margin-top: 17px;
+    margin-top: 19px;
 }
 
-.scb_s_homepage_footer_support,.scb_s_homepage_footer_about {
+.scb_s_homepage_footer_support {
     vertical-align: top;
     font-size:9pt;
     position: relative;
-    top:17px;
+    top:19px;
     color: #727272;
 }
 

--- a/html_app/ui/homepage.soy
+++ b/html_app/ui/homepage.soy
@@ -9,16 +9,16 @@
 {template .main}
 <div class='scb_s_homepage_view' >
     {call .display_header}
-    {param global_template:$global_template /}
-    {param context:$context /}
+        {param global_template:$global_template /}
+        {param context:$context /}
     {/call}
     {call scb_common.assignment_step}
-    {param step:0/}
-    {param last_step: $last_step/}
+        {param step:0/}
+        {param last_step: $last_step/}
     {/call}
     {call .display_content/}
     {call .display_footer}
-    {param global_template:$global_template /}
+        {param global_template:$global_template /}
     {/call}
 </div>
 {/template}
@@ -31,7 +31,6 @@ Assignment title
 {template .display_header}
 <div class='scb_s_header' role='header'>
     <div alt='' class='scb_s_header_line_top' ></div>
-
     <h1 class='scb_s_logo_h1' aria-label='StarCellBio Home Page Link' >
         <a aria-hidden='true' href='{if $context.auth and $context.auth.logged_in}#view=assignments{else}#view=homepage{/if}'>
             StarCellBio<img class='scb_s_logo' src='images/header/scb_logo.png' role='banner'>
@@ -40,7 +39,7 @@ Assignment title
     <div class='scb_s_header_tools'>
         <button class='scb_f_contact' aria-label='Contact'>
             <img class='scb_s_header_tools_icon' src='images/header/scb_envelope_icon.png' alt='' role='presentation'>
-        	<span class='scb_s_header_tools_text' role='presentation'>CONTACT</span>
+            <span class='scb_s_header_tools_text' role='presentation'>CONTACT</span>
         </button>
         <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' alt='' role='presentation'>
         <a class='scb_f_reference' href='/static/ref_lib/full_library.html#' aria-label='Library' target='_blank'>
@@ -52,24 +51,23 @@ Assignment title
             <img class='scb_s_header_tools_icon' src='images/header/scb_user_guide_icon.png' role='presentation'>
             <span class='scb_s_header_tools_text' role='presentation'>USER<br>GUIDE</span>
         </button>
-    	<img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' role='presentation'>
-		<a class='scb_f_video' href='http://www.youtube.com/playlist?list=PLZhxzzyMIQIHhQ2TOGm3HNLA04ZsTmOLW'
-		    role='link'  aria-label='Videos' target="_blank">
+        <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' role='presentation'>
+        <a class='scb_f_video' href='http://www.youtube.com/playlist?list=PLZhxzzyMIQIHhQ2TOGm3HNLA04ZsTmOLW'
+            role='link'  aria-label='Videos' target="_blank">
             <img class='scb_s_header_tools_icon' src='images/header/scb_video_icon.png' role='presentation'>
             <span class='scb_s_header_tools_text' role='presentation'>VIDEOS</span>
         </a>
         <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' alt='' role='presentation'>
         <a class='scb_f_login' href='#view=assignments' role='presentation' aria-label='Sign In link'>
             <span class='scb_s_login_status' aria-hidden='true'>
-            	{if $context.auth and $context.auth.logged_in}
-            		SIGN OUT
-            	{else}
-            		SIGN IN
-            	{/if}
+                {if $context.auth and $context.auth.logged_in}
+                    SIGN OUT
+                {else}
+                    SIGN IN
+                {/if}
             </span>
         </a>
     </div>
-
     <div id='saving'>
         Saving...
         <div id='saving_message'>
@@ -88,10 +86,12 @@ Assignment footer
 <div class='scb_s_homepage_content' role='main'>
     <span class='scb_s_homepage_top' role='welcome_to_starcellbio'>
         <span class='scb_s_homepage_top_left'>
-		<span class='scb_s_homepage_top_left_text'>
-			<b>Welcome to StarCellBio,</b><br/> a virtual experiment simulation <br/>tool that teaches the fundamental concepts of cell and molecular <br/>biology, experimental design, and analysis. 
-
-		</span>
+            <span class='scb_s_homepage_top_left_text'>
+                <b>Welcome to StarCellBio,</b><br>
+                a virtual experiment simulation<br>
+                tool that teaches the fundamental concepts of cell and molecular<br>
+                biology, experimental design, and analysis.
+            </span>
         </span>
         <span class='scb_s_homepage_top_right' role='signup_area'>
             <iframe width="100%" height="194" src="//www.youtube.com/embed/RqDHjjI-GHg" frameborder="0" allowfullscreen></iframe>
@@ -131,33 +131,40 @@ Assignment display_experiment_design
                 </span>
                 <div class='scb_s_homepage_experimental_design_list_items'>
                     <div class='scb_s_homepage_experimental_design_bullet_item' value='Design' data-id="design" role="link"
-                          aria-controls='scb_s_homepage_experimental_design_list_info'>
-                        <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >1.</span>
-                        <span class='scb_s_homepage_experimental_design_item'>Design</span></div>
+                         aria-controls='scb_s_homepage_experimental_design_list_info'>
+                         <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >1.</span>
+                         <span class='scb_s_homepage_experimental_design_item'>Design</span>
+                    </div>
                     <div class='scb_s_homepage_experimental_design_bullet_item' value='SetUp' data-id="setup" role="link"
-                          aria-controls='scb_s_homepage_experimental_design_list_info'>
-                        <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >2.</span>
-                        <span class='scb_s_homepage_experimental_design_item'>Setup</span></div>
+                         aria-controls='scb_s_homepage_experimental_design_list_info'>
+                         <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >2.</span>
+                         <span class='scb_s_homepage_experimental_design_item'>Setup</span>
+                    </div>
                     <div class='scb_s_homepage_experimental_design_bullet_item' value ='RunExperiment' data-id="run_experiment" role="link"
-                          aria-controls='scb_s_homepage_experimental_design_list_info'>
-                        <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >3.</span>
-                        <span class='scb_s_homepage_experimental_design_item'>Run Experiment</span></div>
+                         aria-controls='scb_s_homepage_experimental_design_list_info'>
+                         <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >3.</span>
+                         <span class='scb_s_homepage_experimental_design_item'>Run Experiment</span>
+                    </div>
                     <div class='scb_s_homepage_experimental_design_bullet_item'  value='SelectTechniques' data-id="select_technique" role="link"
-                          aria-controls='scb_s_homepage_experimental_design_list_info'>
-                        <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >4.</span>
-                        <span class='scb_s_homepage_experimental_design_item'>Select Technique(s)</span></div>
-                    <div class='scb_s_homepage_experimental_design_bullet_item' value='RunTechniques'  data-id="run_technique" role="link"
-                          aria-controls='scb_s_homepage_experimental_design_list_info'>
-                        <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >5.</span>
-                        <span class='scb_s_homepage_experimental_design_item'>Run Technique(s)</span></div>
+                         aria-controls='scb_s_homepage_experimental_design_list_info'>
+                         <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >4.</span>
+                         <span class='scb_s_homepage_experimental_design_item'>Select Technique(s)</span>
+                    </div>
+                    <div class='scb_s_homepage_experimental_design_bullet_item' value='RunTechniques' data-id="run_technique" role="link"
+                         aria-controls='scb_s_homepage_experimental_design_list_info'>
+                         <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >5.</span>
+                         <span class='scb_s_homepage_experimental_design_item'>Run Technique(s)</span>
+                    </div>
                     <div class='scb_s_homepage_experimental_design_bullet_item' value='Analyze' data-id="analyze" role="link"
-                          aria-controls='scb_s_homepage_experimental_design_list_info'>
-                        <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >6.</span>
-                        <span class='scb_s_homepage_experimental_design_item'>Analyze</span></div>
+                         aria-controls='scb_s_homepage_experimental_design_list_info'>
+                         <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >6.</span>
+                         <span class='scb_s_homepage_experimental_design_item'>Analyze</span>
+                    </div>
                     <div class='scb_s_homepage_experimental_design_bullet_item' value='Conclude' data-id="conclude" role="link"
-                          aria-controls='scb_s_homepage_experimental_design_list_info'>
-                        <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >7.</span>
-                        <span class='scb_s_homepage_experimental_design_item'>Conclude</span></div>
+                         aria-controls='scb_s_homepage_experimental_design_list_info'>
+                         <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >7.</span>
+                         <span class='scb_s_homepage_experimental_design_item'>Conclude</span>
+                    </div>
                 </div>
                 <img class='scb_s_homepage_experimental_design_list_bar'
                      src='images/homepage/experimental_design_bar.png' alt=''>
@@ -176,8 +183,7 @@ Assignment display_experiment_design
                 <img src='images/homepage/techniques.png'>
             </span>
             {call scb_homepage.display_techniques}
-            {param techniques:['wb','fc','micro']/}
-
+                {param techniques:['wb','fc','micro']/}
             {/call}
         </span>
     </span>
@@ -188,40 +194,38 @@ Assignment display_experiment_design
 */
 {template .display_techniques}
 {foreach $tech in $techniques}
-{if $tech == 'wb'}
-<span class='scb_s_homepage_technique_wb'>
-    <span class='scb_s_homepage_technique_title_image' role='heading' >Western Blot</span>
-    Western blotting detects overall changes in the amount or chemical modifications of a particular protein.
-    <a href="static/ref_lib/full_library.html#WesternBlotting" role='button' class='scb_s_homepage_technique_learn_more' target='_blank'
-       aria-label='Learn more about western blot'>LEARN MORE</a>
-
-</span>
-<img class='scb_s_homepage_technique_bar'
-     src='images/homepage/experimental_design_bar.png' role='presentation' alt=''>
-{/if}
-{if $tech == 'fc'}
-<span class='scb_s_homepage_technique_flow'>
-    <span class='scb_s_homepage_technique_title_image' role='heading'>Flow Cytometry</span>
-    Flow cytometry is used to count and analyze the size, shape and properties of
-    individual cells within a heterogeneous population of cells.
-    <a href="static/ref_lib/full_library.html#FlowCytometry" role='button' class='scb_s_homepage_technique_learn_more' target='_blank'
-       aria-label='Learn more about flow cytometry'>LEARN MORE</a>
-</span>
-<img class='scb_s_homepage_technique_bar'
-     src='images/homepage/experimental_design_bar.png' role='presentation' alt=''>
-{/if}
-{if $tech == 'micro'}
-<span class='scb_s_homepage_technique_micro'>
-    <span class='scb_s_homepage_technique_title_image' role='heading'>Microscopy</span>
-    Microscopy is used to study the shape, morphology and properties of cells,
-    tissues or organisms that otherwise cannot be observed by eye.
-    <a href="static/ref_lib/full_library.html#Microscopy" role='button' class='scb_s_homepage_technique_learn_more' target='_blank'
-       aria-label='Learn more about microscopy'>LEARN MORE</a>
-</span>
-{/if}
-<!--
-<img class='scb_s_homepage_technique_more' src='images/homepage/more_techniques.png'>
--->
+    {if $tech == 'wb'}
+        <span class='scb_s_homepage_technique_wb'>
+            <span class='scb_s_homepage_technique_title_image' role='heading' >Western Blot</span>
+            Western blotting detects overall changes in the amount or chemical modifications of a particular protein.
+            <a href="static/ref_lib/full_library.html#WesternBlotting" role='button' class='scb_s_homepage_technique_learn_more' target='_blank'
+               aria-label='Learn more about western blot'>LEARN MORE
+            </a>
+        </span>
+        <img class='scb_s_homepage_technique_bar'
+             src='images/homepage/experimental_design_bar.png' role='presentation' alt=''>
+    {/if}
+    {if $tech == 'fc'}
+        <span class='scb_s_homepage_technique_flow'>
+            <span class='scb_s_homepage_technique_title_image' role='heading'>Flow Cytometry</span>
+            Flow cytometry is used to count and analyze the size, shape and properties of
+            individual cells within a heterogeneous population of cells.
+            <a href="static/ref_lib/full_library.html#FlowCytometry" role='button' class='scb_s_homepage_technique_learn_more' target='_blank'
+               aria-label='Learn more about flow cytometry'>LEARN MORE
+            </a>
+        </span>
+        <img class='scb_s_homepage_technique_bar'
+             src='images/homepage/experimental_design_bar.png' role='presentation' alt=''>
+    {/if}
+    {if $tech == 'micro'}
+        <span class='scb_s_homepage_technique_micro'>
+            <span class='scb_s_homepage_technique_title_image' role='heading'>Microscopy</span>
+            Microscopy is used to study the shape, morphology and properties of cells,
+            tissues or organisms that otherwise cannot be observed by eye.
+            <a href="static/ref_lib/full_library.html#Microscopy" role='button' class='scb_s_homepage_technique_learn_more' target='_blank'
+               aria-label='Learn more about microscopy'>LEARN MORE</a>
+        </span>
+    {/if}
 {/foreach}
 {/template}
 /**
@@ -232,14 +236,12 @@ Assignment display_experiment_design
     <a href="http://web.mit.edu/" role='link'>
         <img class='scb_s_homepage_footer_logo' src='images/homepage/mit_logo.png' alt='MIT Logo'>
     </a>
-
     <img class='scb_s_homepage_footer_divider' role='presentation'  src='images/homepage/small_divider.png' alt=''>
     <a href='http://star.mit.edu/CellBio/funding/index.html' role='link' aria-label='Funding' target='_blank'>
         <span aria-hidden='true' class='scb_s_homepage_footer_support' src='images/homepage/support.png'>
             Funding
         </span>
     </a>
-
 </div>
 {/template}
 
@@ -284,4 +286,3 @@ Analyze the results of your experiment.
 {template .experimental_design_conclude}
 Form a conclusion that addresses how your results fit your original hypothesis.
 {/template}
-

--- a/html_app/ui/homepage.soy
+++ b/html_app/ui/homepage.soy
@@ -231,14 +231,12 @@ Assignment display_experiment_design
 */
 {template .display_footer}
 <div class='scb_s_footer' role='footer'>
-    <a href="http://web.mit.edu/">
-        <img class='scb_s_homepage_footer_logo' src='images/homepage/mit_logo.png' alt='MIT Logo'>
+    <a class='scb_s_homepage_footer_logo' href="http://web.mit.edu/" aria-label='MIT Logo'>
+        <img src='images/homepage/mit_logo.png' role="presentation" alt=''>
     </a>
-    <img class='scb_s_homepage_footer_divider' role='presentation'  src='images/homepage/small_divider.png' alt=''>
-    <a href='http://star.mit.edu/CellBio/funding/index.html' aria-label='Funding' target='_blank'>
-        <span aria-hidden='true' class='scb_s_homepage_footer_support' src='images/homepage/support.png'>
-            Funding
-        </span>
+    <img class='scb_s_homepage_footer_divider' src='images/homepage/small_divider.png' role='presentation' alt=''>
+    <a class='scb_s_homepage_footer_support' href='http://star.mit.edu/CellBio/funding/index.html' target='_blank'>
+        Funding
     </a>
 </div>
 {/template}

--- a/html_app/ui/homepage.soy
+++ b/html_app/ui/homepage.soy
@@ -130,41 +130,41 @@ Assignment display_experiment_design
                 Each experiment consists of 7 steps:
                 </span>
                 <div class='scb_s_homepage_experimental_design_list_items'>
-                    <div class='scb_s_homepage_experimental_design_bullet_item' value='Design' data-id="design" role="link"
+                    <button class='scb_s_homepage_experimental_design_bullet_item' value='Design' data-id="design"
                          aria-controls='scb_s_homepage_experimental_design_list_info'>
                          <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >1.</span>
-                         <span class='scb_s_homepage_experimental_design_item'>Design</span>
-                    </div>
-                    <div class='scb_s_homepage_experimental_design_bullet_item' value='SetUp' data-id="setup" role="link"
+                         Design
+                    </button>
+                    <button class='scb_s_homepage_experimental_design_bullet_item' value='SetUp' data-id="setup"
                          aria-controls='scb_s_homepage_experimental_design_list_info'>
                          <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >2.</span>
-                         <span class='scb_s_homepage_experimental_design_item'>Setup</span>
-                    </div>
-                    <div class='scb_s_homepage_experimental_design_bullet_item' value ='RunExperiment' data-id="run_experiment" role="link"
+                         Setup
+                    </button>
+                    <button class='scb_s_homepage_experimental_design_bullet_item' value ='RunExperiment' data-id="run_experiment"
                          aria-controls='scb_s_homepage_experimental_design_list_info'>
                          <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >3.</span>
-                         <span class='scb_s_homepage_experimental_design_item'>Run Experiment</span>
-                    </div>
-                    <div class='scb_s_homepage_experimental_design_bullet_item'  value='SelectTechniques' data-id="select_technique" role="link"
+                         Run Experiment
+                    </button>
+                    <button class='scb_s_homepage_experimental_design_bullet_item'  value='SelectTechniques' data-id="select_technique"
                          aria-controls='scb_s_homepage_experimental_design_list_info'>
                          <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >4.</span>
-                         <span class='scb_s_homepage_experimental_design_item'>Select Technique(s)</span>
-                    </div>
-                    <div class='scb_s_homepage_experimental_design_bullet_item' value='RunTechniques' data-id="run_technique" role="link"
+                         Select Technique(s)
+                    </button>
+                    <button class='scb_s_homepage_experimental_design_bullet_item' value='RunTechniques' data-id="run_technique"
                          aria-controls='scb_s_homepage_experimental_design_list_info'>
                          <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >5.</span>
-                         <span class='scb_s_homepage_experimental_design_item'>Run Technique(s)</span>
-                    </div>
-                    <div class='scb_s_homepage_experimental_design_bullet_item' value='Analyze' data-id="analyze" role="link"
+                         Run Technique(s)
+                    </button>
+                    <button class='scb_s_homepage_experimental_design_bullet_item' value='Analyze' data-id="analyze"
                          aria-controls='scb_s_homepage_experimental_design_list_info'>
                          <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >6.</span>
-                         <span class='scb_s_homepage_experimental_design_item'>Analyze</span>
-                    </div>
-                    <div class='scb_s_homepage_experimental_design_bullet_item' value='Conclude' data-id="conclude" role="link"
+                         Analyze
+                    </button>
+                    <button class='scb_s_homepage_experimental_design_bullet_item' value='Conclude' data-id="conclude"
                          aria-controls='scb_s_homepage_experimental_design_list_info'>
                          <span class='scb_s_homepage_experimental_design_bullet' role="presentation" aria-hidden="true" >7.</span>
-                         <span class='scb_s_homepage_experimental_design_item'>Conclude</span>
-                    </div>
+                         Conclude
+                    </button>
                 </div>
                 <img class='scb_s_homepage_experimental_design_list_bar'
                      src='images/homepage/experimental_design_bar.png' alt=''>

--- a/html_app/ui/homepage.soy
+++ b/html_app/ui/homepage.soy
@@ -30,12 +30,10 @@ Assignment title
 */
 {template .display_header}
 <div class='scb_s_header' role='header'>
-    <div alt='' class='scb_s_header_line_top' ></div>
-    <h1 class='scb_s_logo_h1' aria-label='StarCellBio Home Page Link' >
-        <a aria-hidden='true' href='{if $context.auth and $context.auth.logged_in}#view=assignments{else}#view=homepage{/if}'>
-            StarCellBio<img class='scb_s_logo' src='images/header/scb_logo.png' role='banner'>
-        </a>
-    </h1>
+    <div class='scb_s_header_line_top'></div>
+    <a class='scb_s_logo' role='banner' aria-label='StarCellBio Home Page Link' href='{if $context.auth and $context.auth.logged_in}#view=assignments{else}#view=homepage{/if}'>
+        <img width="250px" src='images/header/scb_logo.png' role='presentation'>
+    </a>
     <div class='scb_s_header_tools'>
         <button class='scb_f_contact' aria-label='Contact'>
             <img class='scb_s_header_tools_icon' src='images/header/scb_envelope_icon.png' alt='' role='presentation'>

--- a/html_app/ui/homepage.soy
+++ b/html_app/ui/homepage.soy
@@ -53,7 +53,7 @@ Assignment title
         </button>
         <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' role='presentation'>
         <a class='scb_f_video' href='http://www.youtube.com/playlist?list=PLZhxzzyMIQIHhQ2TOGm3HNLA04ZsTmOLW'
-            role='link'  aria-label='Videos' target="_blank">
+            aria-label='Videos' target="_blank">
             <img class='scb_s_header_tools_icon' src='images/header/scb_video_icon.png' role='presentation'>
             <span class='scb_s_header_tools_text' role='presentation'>VIDEOS</span>
         </a>
@@ -99,11 +99,11 @@ Assignment footer
                 Try an Experiment
             </a>
             <img class='scb_s_homepage_blue_line' src='images/homepage/horizontal_line.png' alt=''>
-            <button class='scb_f_create_instructors_account scb_s_homepage_blue_actions' role='button'>
+            <button class='scb_f_create_instructors_account scb_s_homepage_blue_actions'>
                 Create Instructors Account
             </button>
             <img class='scb_s_homepage_blue_line' src='images/homepage/horizontal_line.png' alt=''>
-            <button class='scb_f_create_student_account scb_s_homepage_blue_actions' role='button'>
+            <button class='scb_f_create_student_account scb_s_homepage_blue_actions'>
                 Create Student Account
             </button>
             <br>
@@ -173,7 +173,7 @@ Assignment display_experiment_design
                     Euismod tincidunt ut laoreet dolore magna kjowkd aliquam erat volu
                 </span>
                 <a href="static/ref_lib/full_library.html#ExperimentalDesign"
-                   class='scb_s_homepage_learn_more scb_s_homepage_technique_learn_more learn_more_dynamic' target='_blank' aria-label='Learn more about this step' role='button'>
+                   class='scb_s_homepage_learn_more scb_s_homepage_technique_learn_more learn_more_dynamic' target='_blank' aria-label='Learn more about this step'>
                    LEARN MORE
                 </a>
             </span>
@@ -198,7 +198,7 @@ Assignment display_experiment_design
         <span class='scb_s_homepage_technique_wb'>
             <span class='scb_s_homepage_technique_title_image' role='heading' >Western Blot</span>
             Western blotting detects overall changes in the amount or chemical modifications of a particular protein.
-            <a href="static/ref_lib/full_library.html#WesternBlotting" role='button' class='scb_s_homepage_technique_learn_more' target='_blank'
+            <a href="static/ref_lib/full_library.html#WesternBlotting" class='scb_s_homepage_technique_learn_more' target='_blank'
                aria-label='Learn more about western blot'>LEARN MORE
             </a>
         </span>
@@ -210,7 +210,7 @@ Assignment display_experiment_design
             <span class='scb_s_homepage_technique_title_image' role='heading'>Flow Cytometry</span>
             Flow cytometry is used to count and analyze the size, shape and properties of
             individual cells within a heterogeneous population of cells.
-            <a href="static/ref_lib/full_library.html#FlowCytometry" role='button' class='scb_s_homepage_technique_learn_more' target='_blank'
+            <a href="static/ref_lib/full_library.html#FlowCytometry" class='scb_s_homepage_technique_learn_more' target='_blank'
                aria-label='Learn more about flow cytometry'>LEARN MORE
             </a>
         </span>
@@ -222,7 +222,7 @@ Assignment display_experiment_design
             <span class='scb_s_homepage_technique_title_image' role='heading'>Microscopy</span>
             Microscopy is used to study the shape, morphology and properties of cells,
             tissues or organisms that otherwise cannot be observed by eye.
-            <a href="static/ref_lib/full_library.html#Microscopy" role='button' class='scb_s_homepage_technique_learn_more' target='_blank'
+            <a href="static/ref_lib/full_library.html#Microscopy" class='scb_s_homepage_technique_learn_more' target='_blank'
                aria-label='Learn more about microscopy'>LEARN MORE</a>
         </span>
     {/if}
@@ -233,11 +233,11 @@ Assignment display_experiment_design
 */
 {template .display_footer}
 <div class='scb_s_footer' role='footer'>
-    <a href="http://web.mit.edu/" role='link'>
+    <a href="http://web.mit.edu/">
         <img class='scb_s_homepage_footer_logo' src='images/homepage/mit_logo.png' alt='MIT Logo'>
     </a>
     <img class='scb_s_homepage_footer_divider' role='presentation'  src='images/homepage/small_divider.png' alt=''>
-    <a href='http://star.mit.edu/CellBio/funding/index.html' role='link' aria-label='Funding' target='_blank'>
+    <a href='http://star.mit.edu/CellBio/funding/index.html' aria-label='Funding' target='_blank'>
         <span aria-hidden='true' class='scb_s_homepage_footer_support' src='images/homepage/support.png'>
             Funding
         </span>

--- a/html_app/ui/homepage.soy
+++ b/html_app/ui/homepage.soy
@@ -32,7 +32,7 @@ Assignment title
 <div class='scb_s_header' role='header'>
     <div class='scb_s_header_line_top'></div>
     <a class='scb_s_logo' role='banner' aria-label='StarCellBio Home Page Link' href='{if $context.auth and $context.auth.logged_in}#view=assignments{else}#view=homepage{/if}'>
-        <img width="250px" src='images/header/scb_logo.png' role='presentation'>
+        <img width="250px" src='images/header/scb_logo.png' alt='' role='presentation'>
     </a>
     <div class='scb_s_header_tools'>
         <button class='scb_f_contact' aria-label='Contact'>
@@ -44,15 +44,15 @@ Assignment title
             <img class='scb_s_header_tools_icon' src='images/header/scb_cabinet_icon.png' alt='' role='presentation'>
             <span class='scb_s_header_tools_text'>LIBRARY</span>
         </a>
-        <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' role='presentation'>
+        <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' alt='' role='presentation'>
         <button class='scb_f_user_guide' aria-label='User Guide' >
-            <img class='scb_s_header_tools_icon' src='images/header/scb_user_guide_icon.png' role='presentation'>
+            <img class='scb_s_header_tools_icon' src='images/header/scb_user_guide_icon.png' alt='' role='presentation'>
             <span class='scb_s_header_tools_text' role='presentation'>USER<br>GUIDE</span>
         </button>
-        <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' role='presentation'>
+        <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' alt='' role='presentation'>
         <a class='scb_f_video' href='http://www.youtube.com/playlist?list=PLZhxzzyMIQIHhQ2TOGm3HNLA04ZsTmOLW'
             aria-label='Videos' target="_blank">
-            <img class='scb_s_header_tools_icon' src='images/header/scb_video_icon.png' role='presentation'>
+            <img class='scb_s_header_tools_icon' src='images/header/scb_video_icon.png' alt='' role='presentation'>
             <span class='scb_s_header_tools_text' role='presentation'>VIDEOS</span>
         </a>
         <img class='scb_s_header_vertical_line' src='images/header/scb_vertical_divider.png' alt='' role='presentation'>
@@ -178,7 +178,7 @@ Assignment display_experiment_design
         </span>
         <span class='scb_s_homepage_technique' role='techniques'>
             <span class='scb_s_homepage_technique_title'>
-                <img src='images/homepage/techniques.png'>
+                <img src='images/homepage/techniques.png' alt=''>
             </span>
             {call scb_homepage.display_techniques}
                 {param techniques:['wb','fc','micro']/}

--- a/html_app/ui/homepage.soy
+++ b/html_app/ui/homepage.soy
@@ -34,6 +34,9 @@ Assignment title
     <a class='scb_s_logo' role='banner' aria-label='StarCellBio Home Page Link' href='{if $context.auth and $context.auth.logged_in}#view=assignments{else}#view=homepage{/if}'>
         <img width="250px" src='images/header/scb_logo.png' alt='' role='presentation'>
     </a>
+    <div class="scb_s_skip_links">
+        <a href='#' class="scb_s_skip_to_content">Skip to content</a>
+    </div>
     <div class='scb_s_header_tools'>
         <button class='scb_f_contact' aria-label='Contact'>
             <img class='scb_s_header_tools_icon' src='images/header/scb_envelope_icon.png' alt='' role='presentation'>

--- a/html_app/ui/microscopy.soy
+++ b/html_app/ui/microscopy.soy
@@ -416,7 +416,7 @@
     {/if}
 </div>
 </div>        
-<a class='scb_s_navigation_button scb_f_microscopy_prepare_slides' microscopy_id='{$microscopy.id}'
+<a class='scb_s_navigation_button scb_f_microscopy_prepare_slides' href='#' microscopy_id='{$microscopy.id}'
    assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'
 {if $can_prepare_slide}{else}disabled='disabled'{/if} role='button'> PREPARE SLIDES  &nbsp; &#9654;
 </a>

--- a/html_app/ui/western_blot.soy
+++ b/html_app/ui/western_blot.soy
@@ -339,7 +339,7 @@
 </div>
 
 </div>
-<a class='scb_s_navigation_button scb_f_western_blot_prepare_lysates' western_blot_id='{$western_blot.id}'
+<a class='scb_s_navigation_button scb_f_western_blot_prepare_lysates' href="#" western_blot_id='{$western_blot.id}'
    assignment_id='{$assignment.id}' experiment_id='{$experiment.id}'
 {if $can_prepare_lysate}{else}disabled='disabled'{/if}  role='button'  aria-label='Prepare Lysates'> PREPARE LYSATES  &nbsp; &#9654;
 </a>

--- a/html_app/ui/western_blot_gel.gss
+++ b/html_app/ui/western_blot_gel.gss
@@ -8,16 +8,14 @@
 }
 .scb_s_wb_primary_antibody > div {
     font-family: 'sourcesanspro-regular';
-
 }
 
-.scb_western_blot_details_view>.scb_s_experiment_step{
-        
+.scb_western_blot_details_view > .scb_s_experiment_step {
 }
 
-.scb_s_wb_analysis_tools_title{
-position: absolute;
-top: 139px;
+.scb_s_wb_analysis_tools_title {
+    position: absolute;
+    top: 139px;
 }
 
 .scb_s_wb_secondary_antibody {
@@ -29,8 +27,7 @@ top: 139px;
 }
 
 .scb_s_wb_secondary_antibody > div {
-font-family: 'sourcesanspro-regular';
-
+    font-family: 'sourcesanspro-regular';
 }
 
 .scb_s_western_blot_blot_and_develop {
@@ -40,44 +37,36 @@ font-family: 'sourcesanspro-regular';
     width: 160px;
 }
 
-
-
 .scb_s_western_blot_reprobe {
     position: absolute;
     top: 252px;
     width:150px;
 }
 
-
-
- label.custom-select_gel{
+label.custom-select_gel {
     position: relative;
     display: inline-block;
-	height: 19px;
+    height: 19px;
 }
 
-.custom-select_gel:hover{
+.custom-select_gel:hover {
   background: url("../images/setup/scb_experiment_dropdown_hover.png") no-repeat right #FFF;
-
 }
 
-.custom-select_gel {  
-	
-	width: 169px;
-	
-  height: 21px;
-  padding-right: 4px;
-  padding-top: 4px;
-  padding-bottom: 3px;
-  padding-left: 8px;
-  overflow: hidden;
-  background: url("../images/setup/scb_experiment_dropdown.png") no-repeat right #FFF;
-  box-shadow: inset 1px 1px 3px 1px rgba(0, 0, 0, 0.3);
+.custom-select_gel {
+    width: 169px;
+    height: 21px;
+    padding-right: 4px;
+    padding-top: 4px;
+    padding-bottom: 3px;
+    padding-left: 8px;
+    overflow: hidden;
+    background: url("../images/setup/scb_experiment_dropdown.png") no-repeat right #FFF;
+    box-shadow: inset 1px 1px 3px 1px rgba(0, 0, 0, 0.3);
 }
 
 .custom-select_gel select {
-
-	background: transparent;
+   background: transparent;
    width: 169px;
    color: #316f94;
    font-family: Arial;
@@ -90,7 +79,6 @@ font-family: 'sourcesanspro-regular';
    -webkit-appearance: none;
    bottom: 1px;
    outline: none;
-
 }
 
 .scb_f_slider {
@@ -113,7 +101,7 @@ font-family: 'sourcesanspro-regular';
     width:1px;
 }
 
-.scb_s_western_blot_choose_samples_marker > li{
+.scb_s_western_blot_choose_samples_marker > li {
     font-size:10pt;
     color:black;
     left: 0px;
@@ -121,7 +109,7 @@ font-family: 'sourcesanspro-regular';
 }
 
 .scb_s_western_blot_view_gel {
-        background: #F4F6F8;
+    background: #F4F6F8;
     width:1002px;
 }
 
@@ -136,7 +124,6 @@ font-family: 'sourcesanspro-regular';
     color:white;
     font-size: 12px;
     text-align: center;
-
 }
 
 .scb_f_vslider_value {
@@ -149,10 +136,9 @@ font-family: 'sourcesanspro-regular';
     width:20px;
     color:white;
     text-align: center;
-
 }
 
-.scb_s_western_blot_gel_left_western_blot{
+.scb_s_western_blot_gel_left_western_blot {
     margin-left: -11px;
     border:inherit;
     background: 0;
@@ -165,8 +151,7 @@ font-family: 'sourcesanspro-regular';
     top: 4px;
 }
 
-
-.scb_s_western_blot_gel_right_western_blot{
+.scb_s_western_blot_gel_right_western_blot {
     border:inherit;
     background: 0;
     vertical-align: text-top;
@@ -178,32 +163,30 @@ font-family: 'sourcesanspro-regular';
     top: 4px;
 }
 
-.scb_s_western_blot_gel_left_western_blot:enabled:hover{
-	background-image: url('../images/western_blot/scb_mini_gray_left_arrow_hover.png') !important;
+.scb_s_western_blot_gel_left_western_blot:enabled:hover {
+    background-image: url('../images/western_blot/scb_mini_gray_left_arrow_hover.png') !important;
 }
 
-.scb_s_western_blot_gel_right_western_blot:enabled:hover{
-	background-image: url('../images/western_blot/scb_mini_gray_right_arrow_hover.png') !important;
+.scb_s_western_blot_gel_right_western_blot:enabled:hover {
+    background-image: url('../images/western_blot/scb_mini_gray_right_arrow_hover.png') !important;
 }
 
-.scb_s_western_blot_gel_left_western_blot:enabled{
+.scb_s_western_blot_gel_left_western_blot:enabled {
     color: #29a592;
     cursor: pointer;
     background-image: url("../../images/western_blot/scb_mini_gray_left_arrow_active.png");
     background-repeat: no-repeat;
 }
 
-.scb_s_western_blot_gel_right_western_blot:enabled{
+.scb_s_western_blot_gel_right_western_blot:enabled {
     color: #29a592;
     cursor: pointer;
     background-image: url("../../images/western_blot/scb_mini_gray_right_arrow_active.png");
     background-repeat: no-repeat;
 }
 
-
-
-.scb_s_western_blot_choose_gel_type        {
-  margin-left:-1px;
+.scb_s_western_blot_choose_gel_type {
+    margin-left:-1px;
 }
 
 .scb_s_western_blot_gel_canvas_wrapper {
@@ -213,22 +196,22 @@ font-family: 'sourcesanspro-regular';
     margin-top: 25px;
 }
 
-.scb_s_western_blot_gel>.scb_s_western_blot_gel_numbers {
+.scb_s_western_blot_gel > .scb_s_western_blot_gel_numbers {
     margin-left:10px;
     top: 19px;
     font-size: 12px;
 }
 
-.scb_s_western_blot_tools > h1, .scb_s_facs_tools> h1 {
+.scb_s_western_blot_tools > h1, .scb_s_facs_tools > h1 {
     font-size:11pt;
     font-family: 'sourcesanspro-semibold';
     padding-left:5px;
 }
 
-.scb_s_western_blot_open_select_technique{
-	float: left;
-	left: 48px;
-	top: 25px;
+.scb_s_western_blot_open_select_technique {
+    float: left;
+    left: 48px;
+    top: 25px;
 }
 
 .scb_s_western_blot_tools {
@@ -244,9 +227,7 @@ font-family: 'sourcesanspro-regular';
     font-family: 'sourcesanspro-semibold';
     margin-left:5px;
     margin-right:10px;
-
 }
-
 
 .scb_f_wb_exposure_slider {
     border-radius: 7px;
@@ -258,13 +239,13 @@ font-family: 'sourcesanspro-regular';
     left:3px;
 }
 
-.scb_f_wb_exposure_slider > .ui-slider-range{
-        height: 3px;
-        top:3px;
-        border-radius: 2px;
-        left: 3px;
-        margin-right:15px;
-        background: #92beba;
+.scb_f_wb_exposure_slider > .ui-slider-range {
+    height: 3px;
+    top:3px;
+    border-radius: 2px;
+    left: 3px;
+    margin-right:15px;
+    background: #92beba;
 }
 
 .scb_f_wb_exposure_slider > .ui-slider-handle {
@@ -290,151 +271,141 @@ font-family: 'sourcesanspro-regular';
     height: 16px;
 }
 
-
-.scb_f_wb_primary_followup{
-	display:none;
-	left: -48px;
-	position: absolute;
-	width: 205px;
-	background: #f4f6f8;
-	border-radius: 14px;
-	padding: 4px;
-	border: 4px solid white;
-	bottom: 297px;
-	z-index: 100;
- 	text-align: left;
- 	font-size:10pt;
-
+.scb_f_wb_primary_followup {
+    display:none;
+    left: -48px;
+    position: absolute;
+    width: 205px;
+    background: #f4f6f8;
+    border-radius: 14px;
+    padding: 4px;
+    border: 4px solid white;
+    bottom: 297px;
+    z-index: 100;
+    text-align: left;
+    font-size:10pt;
 }
 
-.scb_s_western_blot_primary_info{
-	outline: none;
-	left: 164px;
-	top: 46px;
-	position: absolute;
-	background: none;
-	border: none;
-	height: 23px;
-	width: 23px;
-	color: white;
-	letter-spacing: 1px;
-	font-size: 10pt;
-	font-family: 'sourcesanspro-regular';
-	cursor: pointer;
-	background-image: url('../../images/header/scb_info.png');
-	background-repeat: no-repeat;
-	z-index: 6;
+.scb_s_western_blot_primary_info {
+    outline: none;
+    left: 164px;
+    top: 46px;
+    position: absolute;
+    background: none;
+    border: none;
+    height: 23px;
+    width: 23px;
+    color: white;
+    letter-spacing: 1px;
+    font-size: 10pt;
+    font-family: 'sourcesanspro-regular';
+    cursor: pointer;
+    background-image: url('../../images/header/scb_info.png');
+    background-repeat: no-repeat;
+    z-index: 6;
 }
 
-
-
-.scb_f_wb_secondary_followup{
-	display:none;
-	left: -48px;
-	position: absolute;
-	width: 205px;
-	background: #f4f6f8;
-	border-radius: 14px;
-	padding: 4px;
-	border: 4px solid white;
-	bottom: 246px;
-	z-index: 100;
- 	text-align: left;
- 	font-size:10pt;
-
+.scb_f_wb_secondary_followup {
+    display:none;
+    left: -48px;
+    position: absolute;
+    width: 205px;
+    background: #f4f6f8;
+    border-radius: 14px;
+    padding: 4px;
+    border: 4px solid white;
+    bottom: 246px;
+    z-index: 100;
+    text-align: left;
+    font-size:10pt;
 }
 
-.scb_s_western_blot_secondary_info{
-	outline: none;
-	left: 164px;
-	top: 97px;
-	position: absolute;
-	background: none;
-	border: none;
-	height: 23px;
-	width: 23px;
-	color: white;
-	letter-spacing: 1px;
-	font-size: 10pt;
-	font-family: 'sourcesanspro-regular';
-	cursor: pointer;
-	background-image: url('../../images/header/scb_info.png');
-	background-repeat: no-repeat;
-	z-index: 6;
+.scb_s_western_blot_secondary_info {
+    outline: none;
+    left: 164px;
+    top: 97px;
+    position: absolute;
+    background: none;
+    border: none;
+    height: 23px;
+    width: 23px;
+    color: white;
+    letter-spacing: 1px;
+    font-size: 10pt;
+    font-family: 'sourcesanspro-regular';
+    cursor: pointer;
+    background-image: url('../../images/header/scb_info.png');
+    background-repeat: no-repeat;
+    z-index: 6;
 }
 
-
-.scb_f_wb_exposure_followup{
-	display:none;
-	left: -48px;
-	position: absolute;
-	width: 205px;
-	background: #f4f6f8;
-	border-radius: 14px;
-	padding: 4px;
-	border: 4px solid white;
-	bottom: 164px;
-	z-index: 100;
- 	text-align: left;
- 	font-size:10pt;
-
+.scb_f_wb_exposure_followup {
+    display:none;
+    left: -48px;
+    position: absolute;
+    width: 205px;
+    background: #f4f6f8;
+    border-radius: 14px;
+    padding: 4px;
+    border: 4px solid white;
+    bottom: 164px;
+    z-index: 100;
+    text-align: left;
+    font-size:10pt;
 }
 
-.scb_s_western_blot_exposure_info{
-	outline: none;
-	left: 164px;
-	bottom: 149px;
-	position: absolute;
-	background: none;
-	border: none;
-	height: 23px;
-	width: 23px;
-	color: white;
-	letter-spacing: 1px;
-	font-size: 10pt;
-	font-family: 'sourcesanspro-regular';
-	cursor: pointer;
-	background-image: url('../../images/header/scb_info.png');
-	background-repeat: no-repeat;
-	z-index: 6;
+.scb_s_western_blot_exposure_info {
+    outline: none;
+    left: 164px;
+    bottom: 149px;
+    position: absolute;
+    background: none;
+    border: none;
+    height: 23px;
+    width: 23px;
+    color: white;
+    letter-spacing: 1px;
+    font-size: 10pt;
+    font-family: 'sourcesanspro-regular';
+    cursor: pointer;
+    background-image: url('../../images/header/scb_info.png');
+    background-repeat: no-repeat;
+    z-index: 6;
 }
 
-
-
-.scb_s_western_blot_tools_measure_followup{
-	left: 352px;
-	bottom: 344px;
-	position: absolute;
-	width: 205px;
-	background: #f4f6f8;
-	border-radius: 14px;
-	padding: 4px;
-	border: 4px solid white;
-	z-index: 8;
- 	text-align: left;
- 	font-size:10pt;
- 	font-family: 'sourcesanspro-regular' !important;
+.scb_s_western_blot_tools_measure_followup {
+    left: 352px;
+    bottom: 344px;
+    position: absolute;
+    width: 205px;
+    background: #f4f6f8;
+    border-radius: 14px;
+    padding: 4px;
+    border: 4px solid white;
+    z-index: 8;
+    text-align: left;
+    font-size:10pt;
+    font-family: 'sourcesanspro-regular' !important;
 }
 
-
-.scb_s_western_blot_tools_measure_followup_toggle{
-	outline: none;
-	bottom: 283px;
-	position: relative;
-	left: 347px;
-	background: none;
-	border: none;
-	height: 23px;
-	width: 23px;
-	color: white;
-	letter-spacing: 1px;
-	font-size: 10pt;
-	font-family: 'sourcesanspro-regular';
-	cursor: pointer;
-	background-image: url('../../images/header/scb_help.png');
-	background-repeat: no-repeat;
+.scb_s_western_blot_tools_measure_followup_toggle {
+    outline: none;
+    bottom: 283px;
+    position: relative;
+    left: 347px;
+    background: none;
+    border: none;
+    height: 23px;
+    width: 23px;
+    color: white;
+    letter-spacing: 1px;
+    font-size: 10pt;
+    font-family: 'sourcesanspro-regular';
+    cursor: pointer;
+    background-image: url('../../images/header/scb_help.png');
+    background-repeat: no-repeat;
 }
-button:disabled{
+
+button:disabled {
     cursor: default;
 }
-

--- a/html_app/ui/western_blot_gel.gss
+++ b/html_app/ui/western_blot_gel.gss
@@ -46,7 +46,6 @@
 label.custom-select_gel {
     position: relative;
     display: inline-block;
-    height: 19px;
 }
 
 .custom-select_gel:hover {
@@ -55,14 +54,17 @@ label.custom-select_gel {
 
 .custom-select_gel {
     width: 169px;
-    height: 21px;
+    height: 24px;
     padding-right: 4px;
-    padding-top: 4px;
-    padding-bottom: 3px;
+    padding-top: 2px;
     padding-left: 8px;
     overflow: hidden;
     background: url("../images/setup/scb_experiment_dropdown.png") no-repeat right #FFF;
     box-shadow: inset 1px 1px 3px 1px rgba(0, 0, 0, 0.3);
+}
+
+.custom-select_gel:focus-within {
+   box-shadow: 0 0 2px 2px #1c1c1c; /* Default focus indicator */
 }
 
 .custom-select_gel select {
@@ -72,13 +74,16 @@ label.custom-select_gel {
    font-family: Arial;
    font-weight: normal;
    font-size: 8pt;
-   line-height: 1;
    border: 0;
    border-radius: 0;
    height: 22px;
    -webkit-appearance: none;
    bottom: 1px;
    outline: none;
+}
+
+.custom-select_gel select:focus {
+    box-shadow: none;
 }
 
 .scb_f_slider {

--- a/instructor/common.py
+++ b/instructor/common.py
@@ -1504,7 +1504,7 @@ def microscopy_analyze(request):
             attrs={'multiple': True, 'class': 'box_file', 'data-plural-caption': '{} files are '},
         )},
         labels={'file': mark_safe(
-            'To <b>upload</b> new image(s) <strong>choose a file(s)</strong>'
+            'To <b>upload</b> new image(s) <a href="#"><strong>choose a file(s)</strong></a>'
             '<span class="box_dragndrop"> or drag and drop it to the Image Bank (image size < 2MB)</span>.'
         )},
     )

--- a/instructor/templates/instructor/assignments.html
+++ b/instructor/templates/instructor/assignments.html
@@ -53,23 +53,23 @@
                             </a>
                         </td>
                         <td class='scb_s_dashboard_table_element scb_s_dashboard_table_border'>
-                             <span class='scb_ab_s_dashboard_action scb_ab_f_preview' data-assignment-pk="{{ a.id }}">
+                             <a class='scb_ab_s_dashboard_action scb_ab_f_preview' href="#" data-assignment-pk="{{ a.id }}">
                                  Preview
-                             </span>
+                             </a>
                         </td>
                         <td class='scb_s_dashboard_table_element scb_s_dashboard_table_border'>
-                             <span class='scb_ab_s_dashboard_action
+                             <a class='scb_ab_s_dashboard_action
                                 {% if a.access == 'private' %} scb_ab_f_publish{% else %} disabled scb_ab_s_grayed{% endif %}'
-                                   data-assignment-pk="{{ a.id }}">
+                                href="#" data-assignment-pk="{{ a.id }}">
                                  Publish
-                             </span>
+                             </a>
                         </td>
 
                         <td class='scb_s_dashboard_table_element scb_s_dashboard_table_border scb_ab_s_dashboard_no_right_border'>
-                            <span class='scb_ab_f_delete_assignment scb_s_dashboard_remove_assignment'
-                                  data-assignment-pk="{{ a.id }}" data-access="{{ a.access }}">
+                            <a class='scb_ab_f_delete_assignment scb_s_dashboard_remove_assignment'
+                               href="#" data-assignment-pk="{{ a.id }}" data-access="{{ a.access }}">
                                 <img alt="" title="Delete" role='presentation' src="images/setup/scb_remove.png">
-                            </span>
+                            </a>
                         </td>
                     </tr>
                 {% endfor %}

--- a/instructor/templates/instructor/base.html
+++ b/instructor/templates/instructor/base.html
@@ -80,6 +80,10 @@
             <a class="scb_s_logo" role="banner" aria-label="StarCellBio Home Page Link" href="#view=assignments">
                 <img width="250px" src="images/header/scb_logo.png" alt="" role="presentation">
             </a>
+            <div class="scb_s_skip_links">
+                <a href='#' class="scb_s_skip_to_sidebar">Skip to sidebar</a>
+                <a href='#' class="scb_s_skip_to_content">Skip to content</a>
+            </div>
             <div class="scb_s_header_tools">
                 <button class="scb_f_contact" aria-label="Contact">
                     <img class="scb_s_header_tools_icon" src="images/header/scb_envelope_icon.png" alt="" role="presentation">

--- a/instructor/templates/instructor/base.html
+++ b/instructor/templates/instructor/base.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><META http-equiv='Content-Type' content='text/html; charset=UTF-8'><meta http-equiv='content-type' content='text/html; charset=utf-8'><title>StarCellBio Prototype</title>
+<!DOCTYPE html><html lang='en-US'><head><META http-equiv='Content-Type' content='text/html; charset=UTF-8'><meta http-equiv='content-type' content='text/html; charset=utf-8'><title>StarCellBio Prototype</title>
 <link type="text/css" href="/static/js/skins/lightgray/skin.min.css?_=1417401991" rel="Stylesheet" />
 <link type="text/css" href="/static/scb_ex/gen/addmultipledialog.gss.css?_=1417401991" rel="Stylesheet" />
 <link type="text/css" href="/static/ui/gen/technique_tabs.gss.css?_=1417401991" rel="Stylesheet" />

--- a/instructor/templates/instructor/base.html
+++ b/instructor/templates/instructor/base.html
@@ -77,11 +77,9 @@
 
         <div class="scb_s_instructor_header" role="header">
             <div alt="" class="scb_s_header_line_top"></div>
-            <h1 class="scb_s_logo_h1" aria-label="StarCellBio Home Page Link">
-                <a aria-hidden="true" href="#view=assignments">StarCellBio
-                    <img class="scb_s_logo" src="images/header/scb_logo.png" role="banner">
-                </a>
-            </h1>
+            <a class="scb_s_logo" role="banner" aria-label="StarCellBio Home Page Link" href="#view=assignments">
+                <img width="250px" src="images/header/scb_logo.png" alt="" role="presentation">
+            </a>
             <div class="scb_s_header_tools">
                 <button class="scb_f_contact" aria-label="Contact">
                     <img class="scb_s_header_tools_icon" src="images/header/scb_envelope_icon.png" alt="" role="presentation">
@@ -92,9 +90,9 @@
                     <img class="scb_s_header_tools_icon" src="images/header/scb_cabinet_icon.png" alt="" role="presentation">
                     <span class="scb_s_header_tools_text">LIBRARY</span>
                 </a>
-                <img class="scb_s_header_vertical_line" src="images/header/scb_vertical_divider.png" role="presentation">
+                <img class="scb_s_header_vertical_line" src="images/header/scb_vertical_divider.png" alt="" role="presentation">
                 <button class="scb_f_user_guide" aria-label="User Guide">
-                    <img class="scb_s_header_tools_icon" src="images/header/scb_user_guide_icon.png" role="presentation">
+                    <img class="scb_s_header_tools_icon" src="images/header/scb_user_guide_icon.png" alt="" role="presentation">
                     <span class="scb_s_header_tools_text" role="presentation">USER<br>GUIDE</span>
                 </button>
                 <img class="scb_s_header_vertical_line" src="images/header/scb_vertical_divider.png" alt="" role="presentation">
@@ -107,7 +105,7 @@
         <div class="scb_s_instructor_account_title">Assignment Builder: Beta Version</div>
 
         <div class="scb_s_assignment_step" role="menu" xmlns="http://www.w3.org/1999/html">
-            <a class="scb_s_assignment_step_link scb_f_assignments_step_link scb_s_assignment_step_link_active"
+            <a class="scb_s_assignment_step_link scb_f_assignments_step_link enable-outline scb_s_assignment_step_link_active"
                 href="{% url "common_assignments" %}" aria-label="Assignments" role="menuitem">
                 <div class="scb_s_assignment_step_wrapper" style="position: absolute; left: 29px; bottom: 20px;"
                  aria-hidden="true">
@@ -124,30 +122,19 @@
         {% block extra_body %}
         {% endblock %}
 
-
         <div class="scb_s_footer" role="footer">
-            <a href="http://web.mit.edu/" role="link">
-                <img class="scb_s_instructor_homepage_footer_logo" src="images/homepage/mit_logo.png" alt="MIT Logo">
+            <a class="scb_s_homepage_footer_logo" href="http://web.mit.edu/" aria-label="MIT Logo">
+                <img src="images/homepage/mit_logo.png" role="presentation" alt="">
             </a>
-
-            <img class="scb_s_instructor_homepage_footer_divider" role="presentation"
-                 src="images/homepage/small_divider.png" alt="">
-            <a href="http://star.mit.edu/CellBio/funding/index.html"
-               role="link" aria-label="Funding" target="_blank">
-                <span aria-hidden="true" class="scb_s_instructor_homepage_footer_support"
-                      src="images/homepage/support.png">
-                    Funding
-                </span>
+            <img class="scb_s_homepage_footer_divider" src="images/homepage/small_divider.png" role="presentation" alt="">
+            <a class="scb_s_homepage_footer_support" href="http://star.mit.edu/CellBio/funding/index.html" target="_blank">
+                Funding
             </a>
         </div>
     </div>
 </div>
 
-
-
-
 <script src="//cdn.ravenjs.com/1.1.11/jquery,native/raven.min.js"></script>
 <script> Raven.config('https://7845856fc975496e8dc2130b7140b19c@app.getsentry.com/19461', { whitelistUrls: ['starcellbio.mit.edu'] }).install(); </script>
 </body>
-
 </html>

--- a/instructor/templates/instructor/facs_analyze.html
+++ b/instructor/templates/instructor/facs_analyze.html
@@ -5,8 +5,8 @@
   <div class="scb_ab_s_dialog scb_ab_s_copy_dialog" style="visibility:hidden">
         <div>
             <h1 class="scb_ab_s_dialog_title" role="presentation" aria-label="Copy To Histogram">
-                <span class="scb_ab_s_dialog_title_close scb_ab_f_close_copy_dialog" role="button"
-                      aria-label="Close Create Histogram">×</span>
+                <button class="scb_ab_s_dialog_title_close scb_ab_f_close_copy_dialog" role="button"
+                      aria-label="Close Create Histogram"></button>
                 Copy To
             </h1>
             <div class="scb_ab_s_copy_dialog_body">
@@ -60,14 +60,14 @@
     <div class="scb_ab_s_dialog scb_ab_s_analyze_dialog scb_ab_s_analyze_dialog_histogram" style="visibility:hidden">
         <div>
             <h1 class="scb_ab_s_dialog_title" role="presentation" aria-label="Create Histogram">
-                <span class="scb_ab_s_dialog_title_close scb_ab_f_close_dialog" role="button"
-                      aria-label="Close Create Histogram">×</span>
                 Histogram Tools
+                <button class="scb_ab_s_dialog_title_close scb_ab_f_close_dialog" role="button"
+                      aria-label="Close Create Histogram"></button>
             </h1>
             <div class="scb_ab_s_draw_histogram_view">
                 <div class="scb_ab_s_histogram_tabs">
-                    <div class="scb_ab_s_histogram_tab_not_selected">Select Histogram</div>
-                    <div class="scb_ab_s_histogram_tab_selected">Draw New Histogram</div>
+                    <div class="scb_ab_s_histogram_tab_not_selected"><a href="#">Select Histogram</a></div>
+                    <div class="scb_ab_s_histogram_tab_selected"><a href="#">Draw New Histogram</a></div>
                 </div>
                 <div class="scb_ab_s_draw_new_histogram_content">
                     <div class="scb_ab_s_chosen_sample_heading">
@@ -124,8 +124,8 @@
             </div>
             <div class="scb_ab_s_select_histogram_view" style="display:none">
                 <div class="scb_ab_s_histogram_tabs">
-                    <div class="scb_ab_s_histogram_tab_selected">Select Histogram</div>
-                    <div class="scb_ab_s_histogram_tab_not_selected">Draw New Histogram</div>
+                    <div class="scb_ab_s_histogram_tab_selected"><a href="#">Select Histogram</a></div>
+                    <div class="scb_ab_s_histogram_tab_not_selected"><a href="#">Draw New Histogram</a></div>
                 </div>
                 <div class="scb_ab_s_draw_new_histogram_content">
                     <div class="scb_ab_s_chosen_sample_heading">
@@ -207,9 +207,9 @@
                         <div class="scb_ab_s_col_width_number"></div>
                         <div class="scb_ab_s_col_width_facs_sample">
                             <div class="scb_ab_s_remove_histogram_icon_position">
-                                <span class="scb_ab_s_remove_icon scb_ab_f_remove_histogram"
+                                <button class="scb_ab_s_remove_icon scb_ab_f_remove_histogram"
                                       role="button" data-cell_treatment="{{ cell_treatment }}"
-                                      data-pk="{{ instance.id }}" aria-label="Remove Histogram">×</span>
+                                      data-pk="{{ instance.id }}" aria-label="Remove Histogram"></button>
                             </div>
                             <canvas id="canvas-{{ cell_treatment }}_{{ instance.id }}"
                                 class="scb_ab_s_small_canvas">
@@ -222,10 +222,10 @@
                         </div>
                         <div class="scb_ab_s_edit_icon_container">
                             <div class="scb_ab_col_edit">
-                                <div class="scb_ab_s_histogram_edit_icon scb_ab_f_edit_histogram"
+                                <button class="scb_ab_s_histogram_edit_icon scb_ab_f_edit_histogram"
                                     data-row_id="row-{{ cell_treatment }}_{{ instance.id }}"
                                     data-sample_treatment="{{ cell_treatment }}, {{ analysis }}, {{ condition }}">
-                                </div>
+                                </button>
                             </div>
                         </div>
                         <div class="scb_ab_s_copy_button_container">

--- a/instructor/templates/instructor/micro_analyze.html
+++ b/instructor/templates/instructor/micro_analyze.html
@@ -225,5 +225,9 @@
   </div>
   <script type="text/javascript">
     dialog_open = {{ dialog_open|safe }};
+    if ($('.scb_ab_s_dialog.scb_ab_s_analyze_dialog').is(':visible')) {
+      // Focus on close button
+      $('.scb_ab_s_dialog_title_close.scb_ab_f_close_dialog').focus();
+    }
   </script>
 {% endblock %}

--- a/instructor/templates/instructor/micro_analyze.html
+++ b/instructor/templates/instructor/micro_analyze.html
@@ -5,8 +5,9 @@
   <div class="scb_ab_s_dialog scb_ab_s_analyze_dialog" {% if not mapping_pk %}style="visibility:hidden"{% endif %}>
     <div>
       <h1 class="scb_ab_s_dialog_title" role="presentation" aria-label="Create Histogram">
-        <span class="scb_ab_s_dialog_title_close scb_ab_f_close_dialog" role="button"
-              aria-label="Close Create Histogram">×</span>
+        <button class="scb_ab_s_dialog_title_close scb_ab_f_close_dialog"
+                aria-label="Close Create Histogram">
+        </button>
         Select Image
       </h1>
       <div class="scb_ab_s_select_image_div">
@@ -139,10 +140,11 @@
                         {% with filter_image=image_set|get_item:image_field %}
                           {% if filter_image %}
                             <div class="scb_ab_s_remove_image_icon_position">
-                                <span class="scb_ab_s_remove_icon scb_ab_f_remove_image" role="button"
-                                      data-mapping_id="{{ instance.id }}"
-                                      data-filter="{{ filter }}"
-                                      data-group_id="{{ image_set.id }}" aria-label="Remove Image">×</span>
+                                <button class="scb_ab_s_remove_icon scb_ab_f_remove_image"
+                                        data-mapping_id="{{ instance.id }}"
+                                        data-filter="{{ filter }}"
+                                        data-group_id="{{ image_set.id }}" aria-label="Remove Image">
+                                </button>
                             </div>
                             <img src="{{ filter_image.file.url }}" class="scb_ab_s_small_image"/>
                           {% endif %}
@@ -151,7 +153,10 @@
                     </div>
                   {% endfor %}
                   <div class="scb_ab_s_filtered_image_grid">
-                    <div class="scb_s_ab_trash_icon remove_image_set" data-group_id="{{ image_set.id }}"></div>
+                    <button class="scb_s_ab_trash_icon remove_image_set"
+                            data-group_id="{{ image_set.id }}"
+                            aria-label="Remove Image Set">
+                    </button>
                   </div>
                 </div>
               {% endfor %}
@@ -173,9 +178,10 @@
                   {% for image in instance.images.all %}
                     <div class="scb_ab_s_image_wrapper">
                       <div class="scb_ab_s_remove_image_icon_position">
-                        <span class="scb_ab_s_remove_icon scb_ab_f_remove_image" role="button"
-                              data-mapping_id="{{ instance.id }}"
-                              data-image_id="{{ image.id }}" aria-label="Remove Image">×</span>
+                        <button class="scb_ab_s_remove_icon scb_ab_f_remove_image"
+                                data-mapping_id="{{ instance.id }}"
+                                data-image_id="{{ image.id }}" aria-label="Remove Image">
+                        </button>
                       </div>
                       <img src="{{ image.file.url }}" class="scb_ab_s_small_image"/>
                     </div>

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -871,21 +871,24 @@ input[type="checkbox"].disabled {
 label.custom-dropdown {
     position: relative;
     display: inline-block;
-    height: 21px;
     margin-left: 3px;
 }
 
 .custom-dropdown:hover {
     background: url("../images/setup/scb_experiment_dropdown_hover.png") no-repeat right #FFF;
-    background-size: 27px;
+    background-size: 26px;
 }
 
 .custom-dropdown {
-    padding: 4px 0 4px 5px;
+    padding: 2px 0 2px 5px;
     overflow: hidden;
     background: url("../images/setup/scb_experiment_dropdown.png") no-repeat right #FFF;
-    background-size: 27px;
+    background-size: 26px;
     box-shadow: inset 1px 1px 3px 1px rgba(0, 0, 0, 0.3);
+}
+
+.custom-dropdown:focus-within {
+   box-shadow: 0 0 2px 2px #1c1c1c; /* Default focus indicator */
 }
 
 .custom-dropdown select {
@@ -893,10 +896,14 @@ label.custom-dropdown {
     font-family: Arial;
     font-weight: normal;
     font-size: 10pt;
-    line-height: 1;
     border: 0;
-    height: 20px;
+    height: 24px;
     -webkit-appearance: none;
+    top: 1px;
+}
+
+.custom-dropdown select:focus {
+    box-shadow: none;
 }
 
 /* Microscopy select image dialog */

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -285,6 +285,7 @@ select:disabled {
 
 .scb_ab_s_small_input_box > input {
     width: 40px;
+    height: 17px;
 }
 
 .scb_ab_s_units_input > input {

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -1153,7 +1153,7 @@ label[for="id_file"] {
     font-size: large;
 }
 
-label[for="id_file"] strong {
+label[for="id_file"] a {
     color: #005fb3;
     cursor: pointer;
 }

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -1,12 +1,3 @@
-*:focus {
-    outline: 2px solid #1c1c1c;
-    outline-offset: 1px;
-}
-
-::-moz-focus-inner {
-    border: 0;
-}
-
 .scb_ab_s_input_text_field{
     font-size: 10pt;
     font-family: 'sourcesanspro-regular';
@@ -31,8 +22,7 @@
 }
 
 .scb_ab_s_add_files_input:focus + label, .scb_ab_s_add_files_input_setup:focus + label {
-    outline: 2px solid #1c1c1c;
-    outline-offset: 1px;
+    box-shadow: 0 0 2px 2px #1c1c1c; /* Default focus indicator */
 }
 
 .scb_ab_s_add_files_input, .scb_ab_s_add_files_input_setup {

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -585,8 +585,6 @@ input[type="checkbox"].disabled {
 }
 
 .scb_ab_s_input_headers > div.scb_ab_center_input_header {
-    margin-left: 5px;
-    width: 138px;
     text-align: center;
 }
 

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -1,4 +1,4 @@
-.scb_ab_s_input_text_field{
+.scb_ab_s_input_text_field {
     font-size: 10pt;
     font-family: 'sourcesanspro-regular';
     color: black;
@@ -6,8 +6,9 @@
     margin-left: 27px;
     margin-top: 10px;
     padding: 5px;
-    display:inline-block;
+    display: inline-block;
 }
+
 .scb_ab_s_input_text_area {
     font-size: 10pt;
     font-family: 'sourcesanspro-regular';
@@ -15,7 +16,7 @@
     margin-left: 27px;
     margin-top: 10px;
     padding: 5px;
-    display:inline-block;
+    display: inline-block;
     /* Equivalent to rows = 10, cols = 80 */
     width: 43em;
     height: 10em;
@@ -60,7 +61,7 @@
     border: 0;
 }
 
-.scb_ab_s_form_select_field{
+.scb_ab_s_form_select_field {
     font-family: 'sourcesanspro-regular';
     width: 141px;
     background: white;
@@ -69,11 +70,12 @@
     height: 31px;
     font-style: italic;
 }
-.scb_ab_s_micro_analyze>select.scb_ab_s_form_select_field{
+
+.scb_ab_s_micro_analyze > select.scb_ab_s_form_select_field {
     width: 170px;
 }
 
-.scb_s_instructor_view{
+.scb_s_instructor_view {
     width: 1002px;
     background-color: #f4f6f8;
 }
@@ -125,24 +127,21 @@
     margin-top: 100px;
 }
 
-.scb_ab_s_input_error{
+.scb_ab_s_input_error {
     color: indianred;
     display: inline-block;
     padding-left: 5px;
-
 }
 
-.scb_s_form_errors{
+.scb_s_form_errors {
     color: indianred;
     padding-left: 5px;
     width: 200px;
-
 }
 
 select:disabled {
     opacity: 0.4;
 }
-
 
 .scb_s_sidebar_link_sub_heading {
     font-size: 10pt;
@@ -153,67 +152,73 @@ select:disabled {
     padding: 7px 3px 3px 50px;
     height: 12px;
     color: #010101;
-
 }
+
 /* Course */
 .scb_f_use_existing_course {
     display: none;
 }
-/* Modify Course */
 
-.scb_ab_s_course_list_wrapper{
+/* Modify Course */
+.scb_ab_s_course_list_wrapper {
     position: relative;
     left: 30px;
 }
 
-.scb_ab_s_course_edit_headers{
+.scb_ab_s_course_edit_headers {
     font-family: 'sourcesanspro-semibold';
     display: inline-block;
-    position:relative;
+    position: relative;
     width: 171px;
 }
-.scb_ab_s_select_course_headers{
+
+.scb_ab_s_select_course_headers {
     width: 58px;
 
 }
-.scb_ab_s_error_list{
+
+.scb_ab_s_error_list {
     position:relative;
     color: indianred;
-    display:inline-block;
-
+    display: inline-block;
 }
-.scb_ab_s_course_fields_error_list{
-    left:67px;
-    width:165px;
-    display:inline-block;
-    padding:5px 0 0 0;
+
+.scb_ab_s_course_fields_error_list {
+    left: 67px;
+    width: 165px;
+    display: inline-block;
+    padding: 5px 0 0 0;
     margin:0;
 }
-.scb_ab_s_top_error_list{
-    left:30px;
+
+.scb_ab_s_top_error_list {
+    left: 30px;
     margin-bottom: 10px;
     width: 550px;
 }
-.scb_ab_s_course_form_list{
+
+.scb_ab_s_course_form_list {
     position: relative;
     list-style-type: none;
     left: 12px;
 }
-.scb_ab_s_course_form_list>div{
+
+.scb_ab_s_course_form_list > div {
     display: inline;
 }
-.scb_ab_s_add_course_button_position{
+
+.scb_ab_s_add_course_button_position {
     position: relative;
     left: 67px;
     top: 15px;
 }
 
-
 /* Strains */
-.scb_ab_s_form_container{
+.scb_ab_s_form_container {
     padding-left: 20px;
     padding-top: 10px;
 }
+
 .scb_s_delete_strain {
     border: 0;
     width: 24px;
@@ -224,146 +229,164 @@ select:disabled {
     position: relative;
     left: 16px;
 }
-.scb_ab_s_experiment_setup_add_button{
-	width: 104px;
-    margin:20px 0 0 29px;
+
+.scb_ab_s_experiment_setup_add_button {
+    width: 104px;
+    margin: 20px 0 0 29px;
 }
 
 /* Input headers  in Define variable */
-.scb_ab_s_input_headers{
+.scb_ab_s_input_headers {
     position: relative;
     left: 29px;
-    margin-top:20px;
-
+    margin-top: 20px;
 }
-.scb_ab_s_input_headers>div{
+
+.scb_ab_s_input_headers > div {
     width: 148px;
     display: inline-block;
     font-family: 'sourcesanspro-semibold';
     font-size: 14px ;
 }
-.scb_ab_s_input_headers>div.scb_ab_s_micro_analyze_header{
+
+.scb_ab_s_input_headers > div.scb_ab_s_micro_analyze_header {
     width: 179px;
 }
-.scb_ab_s_input_headers>div.scb_ab_s_small_header{
+
+.scb_ab_s_input_headers > div.scb_ab_s_small_header {
     width: 58px;
 }
-.scb_ab_s_input_headers>div.scb_ab_s_med_header{
+
+.scb_ab_s_input_headers > div.scb_ab_s_med_header {
     width: 130px;
 }
-.scb_ab_s_input_headers>div.scb_ab_s_units_input_header{
+
+.scb_ab_s_input_headers > div.scb_ab_s_units_input_header {
     width:77px;
 }
-.scb_ab_s_input_headers>div.scb_ab_s_time_units_input_header{
+
+.scb_ab_s_input_headers > div.scb_ab_s_time_units_input_header {
     width: 72px;
 }
 
-
 /* Form inputs  in Define variables*/
-.scb_ab_s_form_input_list{
+.scb_ab_s_form_input_list {
     position: relative;
     left: 29px;
 }
-.scb_ab_s_form_input_list>div{
+
+.scb_ab_s_form_input_list > div {
     display: inline-block;
 }
-.scb_ab_s_form_input_list>div>input{
+
+.scb_ab_s_form_input_list > div > input {
     margin: 2px 0 3px 5px;
 }
 
-.scb_ab_s_form_input_list>.scb_ab_s_counter_margin{
+.scb_ab_s_form_input_list > .scb_ab_s_counter_margin {
     margin-left: -19px;
 }
 
-.scb_ab_s_small_input_box>input{
+.scb_ab_s_small_input_box > input {
     width: 40px;
 }
-.scb_ab_s_units_input>input{
+
+.scb_ab_s_units_input > input {
     width: 60px;
 }
-.scb_ab_s_time_units_input>input{
+
+.scb_ab_s_time_units_input > input {
     width: 53px;
 }
-.scb_ab_s_med_input_box>input{
+
+.scb_ab_s_med_input_box > input {
     width: 108px;
 }
+
 /* Delete trash icon*/
-.scb_s_ab_trash_icon{
+.scb_s_ab_trash_icon {
     background: url('images/setup/scb_remove.png') no-repeat;
-    display:inline-block;
-    height:20px;
+    display: inline-block;
+    height: 20px;
     width: 15px;
     background-position: center;
     margin-left: 8px;
     cursor: pointer;
 }
+
 .checkbox_image:hover {
     cursor: pointer;
 }
 
 /* select variables */
-.scb_ab_s_variable_wrapper{
+.scb_ab_s_variable_wrapper {
     margin-bottom: 7px;
 }
-.scb_ab_s_grayed{
+
+.scb_ab_s_grayed {
     color: grey !important;
 }
 
-
-.scb_ab_s_hide_variable{
-    display:none;
+.scb_ab_s_hide_variable {
+    display: none;
 }
 
-.scb_ab_s_row{
+.scb_ab_s_row {
     position: relative;
 }
 
-.scb_ab_s_row>div{
-    display:inline-block;
+.scb_ab_s_row > div {
+    display: inline-block;
     text-align: center;
     vertical-align: top;
 }
-.scb_ab_s_col_width>div{
-    width: 100px;
 
+.scb_ab_s_col_width > div {
+    width: 100px;
 }
 
-.scb_ab_s_table_header_text{
+.scb_ab_s_table_header_text {
     font-family: 'sourcesanspro-semibold';
     margin: 5px 0 10px 0;
 }
-.scb_ab_s_row>div.scb_ab_s_enable_sample{
+
+.scb_ab_s_row > div.scb_ab_s_enable_sample {
     width: 50px;
 }
-.scb_ab_s_heading_div{
+
+.scb_ab_s_heading_div {
     margin: 15px 10px;
     font-family: 'sourcesanspro-semibold';
     color: #316f94;
     font-weight: bold;
-
 }
-.scb_ab_s_page_title{
+
+.scb_ab_s_page_title {
     font-size: 16pt;
     padding-bottom: 10px;
-
 }
-.scb_ab_s_heading_description{
+
+.scb_ab_s_heading_description {
     font-size: 12pt;
 }
-.scb_ab_s_heading_instructions{
+
+.scb_ab_s_heading_instructions {
     font-size: 10pt;
 }
-.scb_ab_s_show_protocols_btn{
+
+.scb_ab_s_show_protocols_btn {
     float: right;
-    margin-right:40px;
+    margin-right: 40px;
     width: 160px;
 }
-.scb_ab_s_samples_heading{
+
+.scb_ab_s_samples_heading {
     display: inline-block;
     padding-left: 10px;
 }
+
 /* Sidebar */
-.scb_ab_s_sidebar_section_heading{
+.scb_ab_s_sidebar_section_heading {
     padding-left: 12px;
     font-size: 14pt;
     font-weight: bold;
@@ -371,7 +394,8 @@ select:disabled {
     color: #316f94;
     padding-top: 5px;
 }
-.scb_ab_s_sidebar_section_subheading{
+
+.scb_ab_s_sidebar_section_subheading {
     padding-left: 14px;
     font-size: 12pt;
     font-weight: bold;
@@ -379,108 +403,121 @@ select:disabled {
     color: #316f94;
     padding-top: 5px;
 }
-.scb_ab_s_sidebar_page_name_selected{
-	background: #c9cdd0;
-}
-.scb_ab_s_sidebar_page_link{
-	font-size: 10pt;
-	margin: 0 0 0 -5px;
-	font-family: 'sourcesanspro-semibold';
-	width: 221px;
-	padding: 7px 3px 5px 33px;
-	color: #010101;
+
+.scb_ab_s_sidebar_page_name_selected {
+    background: #c9cdd0;
 }
 
-.scb_ab_s_sidebar_technique_link{
+.scb_ab_s_sidebar_page_link {
+    font-size: 10pt;
+    margin: 0 0 0 -5px;
+    font-family: 'sourcesanspro-semibold';
+    width: 221px;
+    padding: 7px 3px 5px 33px;
+    color: #010101;
+}
+
+.scb_ab_s_sidebar_technique_link {
     font-size: 10pt;
     margin: 0;
     font-family: 'sourcesanspro-semibold';
     padding: 7px 3px 5px 33px;
     color: #010101;
 }
+
 /* Protein size input */
-div.scb_ab_s_antibody_name{
+div.scb_ab_s_antibody_name {
     text-align: left;
     vertical-align: middle;
     margin-top: 10px;
     width: 155px;
     font-family: 'sourcesanspro-semibold';
-
 }
-.scb_ab_s_protein_sizes_div{
+
+.scb_ab_s_protein_sizes_div {
     width: 271px;
     font-family: 'sourcesanspro-semibold';
 }
-.scb_ab_s_lysate_type_header{
+
+.scb_ab_s_lysate_type_header {
     display: inline-block;
     width: 86px;
 }
-.vertical_align_top{
+
+.vertical_align_top {
     vertical-align: top;
 }
-.scb_ab_s_protein_size_input{
+
+.scb_ab_s_protein_size_input {
     display: inline-block;
     text-align: center;
 }
-.scb_ab_s_protein_size_input>input {
+
+.scb_ab_s_protein_size_input > input {
     margin: 5px 0 0 5px;
     width: 68px;
 }
+
 /* Band intensity*/
-.scb_ab_s_row>.scb_ab_s_col_width_wb_sample{
+.scb_ab_s_row > .scb_ab_s_col_width_wb_sample {
     width: 240px;
     text-align: left;
 }
-.scb_ab_s_row>.scb_ab_s_col_width_number{
+
+.scb_ab_s_row > .scb_ab_s_col_width_number {
     width: 15px;
 }
-.scb_ab_s_col_width_type_size{
+
+.scb_ab_s_col_width_type_size {
     width: 75px;
 }
 
-.scb_ab_s_col_width_intensity>input{
-    display:none;
+.scb_ab_s_col_width_intensity > input {
+    display: none;
 }
-.scb_ab_s_col_width_intensity{
+
+.scb_ab_s_col_width_intensity {
     width: 150px;
 }
-.scb_ab_s_intensity_text{
+
+.scb_ab_s_intensity_text {
     width: 30px;
 }
+
 .intensity_slider {
     border-radius: 7px;
     height: 8px;
     margin-top: 5px;
-    width:130px;
+    width: 130px;
     display: inline-block;
     background: #ebebeb;
 }
 
-.intensity_slider > .ui-slider-range{
+.intensity_slider > .ui-slider-range {
     height: 3px;
-    top:3px;
+    top: 3px;
     border-radius: 2px;
     left: 3px;
-    margin-right:15px;
+    margin-right: 15px;
     background: #92beba;
 }
 
 .intensity_slider > .ui-slider-handle {
     border-radius: 13px;
-    height:15px;
-    width:15px;
+    height: 15px;
+    width: 15px;
     border: 1px solid grey;
 }
-.scb_ab_s_antibody_header{
+
+.scb_ab_s_antibody_header {
     font-size: 17px;
 }
 
-#jqDialog_box{
+#jqDialog_box {
     max-width: 425px;
 }
 
 /* Sample text wrapper with ellipsis */
-
 div.block-ellipsis {
   display: -webkit-box;
   max-width: 100%;
@@ -494,19 +531,23 @@ div.block-ellipsis {
 }
 
 /* Dashboard */
-.scb_ab_s_dashboard_action{
+.scb_ab_s_dashboard_action {
     color: #27956c;
 }
+
 .scb_ab_s_dashboard_no_right_border{
     border-right: 0 !important;
 }
-.scb_s_dashboard_names_width{
+
+.scb_s_dashboard_names_width {
     width: 200px;
 }
-.scb_s_dashboard_access_width{
+
+.scb_s_dashboard_access_width {
     width: 80px;
 }
-.scb_ab_s_dashboard_new_assignment_button{
+
+.scb_ab_s_dashboard_new_assignment_button {
     font-size: 9pt;
     font-family: 'sourcesanspro-semibold';
     position:relative;
@@ -519,117 +560,130 @@ div.block-ellipsis {
     background: #c82e3e;
     color: white;
     padding: 5px 9px 5px 13px;
-
 }
+
 span.scb_ab_s_dashboard_action {
     cursor: pointer;
 }
 
-
 /* Temporarily disable techniques */
-.disabled{
+.disabled {
     opacity: 0.4;
     cursor: default !important;
 }
+
 input[type="checkbox"].disabled {
     opacity: 1;
 }
 
 /* FACS Sample Prep */
-.scb_ab_s_input_headers>div.scb_ab_s_facs_cell_treatment_header{
+.scb_ab_s_input_headers > div.scb_ab_s_facs_cell_treatment_header {
     width: 167px;
-
 }
-.scb_ab_s_input_headers>div.scb_ab_center_input_header{
+
+.scb_ab_s_input_headers > div.scb_ab_center_input_header {
     margin-left: 5px;
     width: 138px;
     text-align: center;
 }
-.scb_ab_s_form_input_list>.scb_ab_s_fixed>input{
+
+.scb_ab_s_form_input_list > .scb_ab_s_fixed > input {
     margin-left: 0;
 }
-.scb_ab_s_form_input_list>.scb_ab_s_live{
+
+.scb_ab_s_form_input_list > .scb_ab_s_live {
     margin-right: 20px;
 }
-.vertical_align_bottom{
+
+.vertical_align_bottom {
     vertical-align: bottom;
 }
+
 /* FACS Analyze */
-.scb_ab_s_col_copy{
+.scb_ab_s_col_copy {
     width: 200px;
 }
-.scb_ab_col_edit{
+
+.scb_ab_col_edit {
     width: 50px;
 }
-.scb_ab_s_edit_icon_container{
+
+.scb_ab_s_edit_icon_container {
     position: absolute;
     top: 50%;
     margin-top: -22px;
     right:222px;
-
 }
-.scb_ab_s_copy_checkbox_container{
+
+.scb_ab_s_copy_checkbox_container {
     position: absolute;
     top: 50%;
     margin-top: -9px;
-    right:17px;
-
+    right: 17px;
 }
-.scb_ab_s_copy_button_container{
+
+.scb_ab_s_copy_button_container {
     position: absolute;
     top: 50%;
     margin-top: -16px;
-    right:30px;
+    right: 30px;
 }
-.scb_ab_s_row>.scb_ab_s_col_width_facs_sample{
+
+.scb_ab_s_row > .scb_ab_s_col_width_facs_sample {
     width: 320px;
     text-align: left;
 }
-.scb_ab_s_row>.scb_ab_s_facs_condition_header{
+
+.scb_ab_s_row > .scb_ab_s_facs_condition_header {
     font-size: 17px;
     width: 339px;
     text-align: left;
-
 }
-.scb_ab_s_grouping_header_row{
+
+.scb_ab_s_grouping_header_row {
     margin: 15px 0 5px 0;
     font-family: 'sourcesanspro-semibold';
 }
-.scb_ab_s_pre_header_row{
+
+.scb_ab_s_pre_header_row {
     margin-bottom: -15px;
     font-family: 'sourcesanspro-semibold';
 }
-.scb_ab_s_histogram_edit_icon{
+
+.scb_ab_s_histogram_edit_icon {
     height: 28px;
     margin: 10px 7px;
 }
+
 .scb_ab_s_edit_grey_img {
     background: url('../images/Draw_Histogram_Gray.png') no-repeat;
     background-size: 25px;
 }
+
 .scb_ab_s_edit_white_img {
     background: url('../images/Draw_Histogram_Green.png') no-repeat;
     background-size: 25px;
 }
 
 /* Dialog view for analyze page */
-.scb_ab_s_dialog{
+.scb_ab_s_dialog {
     position: fixed;
     z-index: 999;
-    top:0px;
+    top: 0px;
     font-family: 'sourcesanspro-regular';
-    font-size:10pt;
+    font-size: 10pt;
 }
-.scb_ab_s_dialog>div{
+
+.scb_ab_s_dialog > div {
     max-height: 75%;
     overflow: auto;
     position: relative;
     border: 2px solid #8d97a3;
     border-radius: 9px;
     background-color: #f5f5f5;
-
 }
-.scb_ab_s_analyze_dialog{
+
+.scb_ab_s_analyze_dialog {
     width:800px;
     left: 300px;
 }
@@ -645,38 +699,40 @@ input[type="checkbox"].disabled {
 }
 
 @media (min-width: 1300px) {
-    .scb_ab_s_analyze_dialog>div{
+    .scb_ab_s_analyze_dialog > div {
         margin: 12% auto auto 0;
     }
 }
 
-.scb_ab_s_copy_dialog{
+.scb_ab_s_copy_dialog {
     width: 400px;
     left: 530px;
-
 }
-.scb_ab_s_copy_dialog>div{
+
+.scb_ab_s_copy_dialog > div {
     margin: 330px auto auto 0;
 
 }
-.scb_ab_s_copy_dialog_body{
+
+.scb_ab_s_copy_dialog_body {
     /*height: 350px;*/
     text-align: center;
     padding-bottom: 50px;
-
 }
-.scb_ab_s_copy_dialog_scroll_list{
+
+.scb_ab_s_copy_dialog_scroll_list {
     height: 200px;
     overflow: scroll;
     box-shadow: inset 2px 2px 5px grey;
 }
-.scb_ab_s_copy_button{
+
+.scb_ab_s_copy_button {
     position: absolute;
     bottom: 10px;
     left: 100px;
 }
 
-.scb_ab_s_grey_button_link{
+.scb_ab_s_grey_button_link {
     background-color: #676767;
     border: 1px solid #e0e0e0;
     border-radius: 5pt;
@@ -718,11 +774,11 @@ input[type="checkbox"].disabled {
 }
 
 /* Draw Histogram View */
-.scb_ab_s_draw_new_histogram_content{
+.scb_ab_s_draw_new_histogram_content {
     margin: 15px;
 }
 
-.scb_ab_s_draw_histogram_canvas{
+.scb_ab_s_draw_histogram_canvas {
     width: 380px;
     height: 365px;
     cursor: inherit;
@@ -731,7 +787,7 @@ input[type="checkbox"].disabled {
     margin: 20px 30px;
 }
 
-.scb_ab_s_small_canvas{
+.scb_ab_s_small_canvas {
     width: 200px;
     height: 200px;
     border: 1px gray solid;
@@ -739,7 +795,7 @@ input[type="checkbox"].disabled {
 }
 
 .scb_ab_s_remove_icon {
-    float:right;
+    float: right;
     height: 26px;
     width: 26px;
     cursor:pointer;
@@ -748,50 +804,55 @@ input[type="checkbox"].disabled {
     background-image: url('../../../images/header/scb_close_button.png');
 }
 
-.scb_ab_s_remove_icon:hover{
+.scb_ab_s_remove_icon:hover {
     background-color: #e58986;
 }
-.scb_ab_s_remove_histogram_icon_position{
-    position:absolute;
+
+.scb_ab_s_remove_histogram_icon_position {
+    position: absolute;
     left: 196px;
     margin-top: -6px;
 }
-.scb_ab_s_chosen_sample_heading{
+
+.scb_ab_s_chosen_sample_heading {
     padding: 0 0 15px 30px;
     text-align: left;
 }
 
 /* Choose histogram tabs in the pop-up window */
-.scb_ab_s_histogram_tabs{
-    display:table;
-    width:100%;
+.scb_ab_s_histogram_tabs {
+    display: table;
+    width: 100%;
     font-family: 'sourcesanspro-semibold';
     overflow: hidden;
-
 }
-.scb_ab_s_histogram_tabs>div{
+
+.scb_ab_s_histogram_tabs > div {
     display: table-cell;
-    text-align:center;
+    text-align: center;
     padding: 5px 0;
     cursor: pointer;
 }
-.scb_ab_s_histogram_tab_not_selected{
+
+.scb_ab_s_histogram_tab_not_selected {
     background: lightgrey;
     box-shadow: inset 2px 2px 5px grey;
-    color:  #737373;
+    color: #737373;
     border:1px solid lightgrey;
 }
-.scb_ab_s_histogram_tab_selected{
+
+.scb_ab_s_histogram_tab_selected {
     background: #27956c;
     box-shadow: 0 0 2px 1px grey;
-    color:  white;
+    color: white;
 }
 
-.scb_ab_s_library_item_wrapper{
+.scb_ab_s_library_item_wrapper {
     display: inline-block;
     margin: 10px;
 }
-.scb_ab_s_canvas_library{
+
+.scb_ab_s_canvas_library {
     margin: 30px 30px 0;
     text-align: center;
     height: 500px;
@@ -800,20 +861,24 @@ input[type="checkbox"].disabled {
     box-shadow: inset 2px 2px 5px grey;
     cursor: auto;
 }
+
 .scb_ab_s_canvas_library_histogram {
     height: 460px;
 }
-.scb_ab_s_save_btn_position{
+
+.scb_ab_s_save_btn_position {
     left: 30px;
-    position:absolute;
+    position: absolute;
     bottom: 0px;
 }
-.scb_ab_s_delete_btn_position{
+
+.scb_ab_s_delete_btn_position {
     right: 30px;
-    position:absolute;
+    position: absolute;
     bottom: 0px;
 }
-.scb_ab_s_histogram_selected{
+
+.scb_ab_s_histogram_selected {
     border: 1px solid indianred;
     box-shadow: 2px 2px 5px indianred;
 }
@@ -822,13 +887,13 @@ input[type="checkbox"].disabled {
     margin-top: 40px;
 }
 
-.scb_ab_s_preview_canvas_div{
+.scb_ab_s_preview_canvas_div {
     z-index: 1000;
     position: absolute;
-    left:150px;
+    left: 150px;
     top: 150px;
-    width:500px;
-    height:300px;
+    width: 500px;
+    height: 300px;
     background-color:darkgrey;
 }
 
@@ -907,66 +972,76 @@ label.custom-dropdown {
 }
 
 /* Microscopy select image dialog */
-.scb_ab_s_image_selected{
+.scb_ab_s_image_selected {
     box-sizing: border-box;
     border: 1px solid #27956c;
     box-shadow: 2px 2px 5px #27956c;
     opacity: 0.5;
 }
-img.scb_ab_s_library_item_wrapper{
+
+img.scb_ab_s_library_item_wrapper {
     max-width: 100px;
     max-height: 100px;
 }
-.scb_ab_s_image_form{
+
+.scb_ab_s_image_form {
     margin-left: 30px;
 }
+
 /*Microscopy analyze */
-.scb_ab_s_small_image{
+.scb_ab_s_small_image {
     width: 100px;
     margin: 0 10px 5px 0;
 }
-.scb_ab_s_row>.scb_ab_s_sample_image_list{
+
+.scb_ab_s_row > .scb_ab_s_sample_image_list {
     width: 450px;
     text-align: left;
     position: relative;
 }
-.scb_ab_s_row>div.scb_ab_s_filtered_image_grid{
+
+.scb_ab_s_row > div.scb_ab_s_filtered_image_grid {
     width: 100px;
     position: relative;
     display: table-cell;
     vertical-align: middle;
 }
-.scb_ab_s_row>button.scb_ab_s_filters_row_name{
+
+.scb_ab_s_row > button.scb_ab_s_filters_row_name {
     width: 130px;
     text-align: left;
     display: table-cell;
     vertical-align: middle;
-
 }
-.scb_ab_s_remove_image_icon_position{
+
+.scb_ab_s_remove_image_icon_position {
     position:absolute;
     left: 80px;
     margin-top: -6px;
 }
-.scb_ab_s_row_offset{
+
+.scb_ab_s_row_offset {
     display: table-cell;
     width: 18px
 }
-.scb_ab_s_image_wrapper{
-    position:relative;
-    display:inline-block;
+
+.scb_ab_s_image_wrapper {
+    position: relative;
+    display: inline-block;
     vertical-align: middle;
     width: 120px;
 }
-.scb_ab_s_select_image_div{
+
+.scb_ab_s_select_image_div {
     height: 650px;
     cursor: move;
 }
-input#id_objective{
+
+input#id_objective {
     width: 30px;
 }
 
-.scb_ab_s_dashboard_icon_active{
+.scb_ab_s_dashboard_icon_active {
     background-image:url('../images/header/dashboard_icon_on.png');
     background-size: cover;
     height: 30px;
@@ -974,7 +1049,7 @@ input#id_objective{
     margin-right: 15px;
 }
 
-.scb_ab_s_tab_title{
+.scb_ab_s_tab_title {
     position: relative;
     top: 5px;
 }
@@ -986,7 +1061,7 @@ input#id_objective{
     letter-spacing: normal;
 }
 
-.scb_ab_s_upload_instruction{
+.scb_ab_s_upload_instruction {
     right: 180px;
     position: absolute;
     margin: 10px 0 0 30px;
@@ -1094,7 +1169,7 @@ label[for="id_file"] strong {
     overflow: hidden;
 }
 
-.scb_f_image_filter>.scb_ab_f_select_image {
+.scb_f_image_filter > .scb_ab_f_select_image {
     margin: 0;
 }
 

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -57,10 +57,6 @@
     margin-left: 27px;
 }
 
-.scb_ab_s_delete_file {
-    border: 0;
-}
-
 .scb_ab_s_form_select_field {
     font-family: 'sourcesanspro-regular';
     width: 141px;
@@ -307,11 +303,17 @@ select:disabled {
 .scb_s_ab_trash_icon {
     background: url('images/setup/scb_remove.png') no-repeat;
     display: inline-block;
-    height: 20px;
-    width: 15px;
+    width: 16px;
+    height: 16px;
     background-position: center;
     margin-left: 8px;
     cursor: pointer;
+    border: none;
+}
+
+.scb_s_ab_trash_icon:hover {
+    outline: 2px solid #ccc;
+    outline-offset: 1px;
 }
 
 .checkbox_image:hover {

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -624,7 +624,7 @@ input[type="checkbox"].disabled {
     max-height: 75%;
     overflow: auto;
     position: relative;
-    border: 5px solid white;
+    border: 2px solid #8d97a3;
     border-radius: 9px;
     background-color: #f5f5f5;
 

--- a/instructor/ui/assignment_setup.css
+++ b/instructor/ui/assignment_setup.css
@@ -651,8 +651,16 @@ input[type="checkbox"].disabled {
 }
 
 .scb_ab_s_histogram_edit_icon {
-    height: 28px;
-    margin: 10px 7px;
+    border: none;
+    width: 25px;
+    height: 25px;
+    margin: 10px 7px 8px 7px;
+    cursor: pointer;
+}
+
+.scb_ab_s_histogram_edit_icon:not([disabled]):hover {
+    outline: 2px solid #ccc;
+    outline-offset: 2px;
 }
 
 .scb_ab_s_edit_grey_img {
@@ -799,9 +807,10 @@ input[type="checkbox"].disabled {
     height: 26px;
     width: 26px;
     cursor:pointer;
+    border: none;
     border-radius: 12px;
     color: transparent;
-    background-image: url('../../../images/header/scb_close_button.png');
+    background: url('../../../images/header/scb_close_button.png') 0 0 / cover no-repeat transparent;
 }
 
 .scb_ab_s_remove_icon:hover {
@@ -832,6 +841,10 @@ input[type="checkbox"].disabled {
     text-align: center;
     padding: 5px 0;
     cursor: pointer;
+}
+
+.scb_ab_s_histogram_tabs a {
+    color: inherit;
 }
 
 .scb_ab_s_histogram_tab_not_selected {

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -795,6 +795,9 @@ $(function() {
         'analysis': analysis,
     });
     addSelectedImages(); // Add already saved images to the selected area
+    // Focus on close button
+    $('.scb_ab_s_dialog_title_close.scb_ab_f_close_dialog').focus();
+    // event.preventDefault();
   });
 
 

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -688,7 +688,7 @@ $(function() {
       } else {
         data = histograms[instance_id]['fixed'];
       }
-      var $edit_icon = $("div.scb_ab_s_histogram_edit_icon[data-row_id='row-" + row_id + "']");
+      var $edit_icon = $(".scb_ab_col_edit>button.scb_ab_s_histogram_edit_icon[data-row_id='row-" + row_id + "']");
       // Scale: editing canvas is 300x300, small canvas is 160x160
       var xyScale = 160/300;
       if (data) {
@@ -702,13 +702,14 @@ $(function() {
           path.add(new Point(xyScale*(point[0] - 20), xyScale*(point[1] + 20)));
         });
         paper.view.update();
-        $("button[data-row_id='row-" + row_id + "']").hide();
+        $(".scb_ab_s_col_width_facs_sample>button[data-row_id='row-" + row_id + "']").hide();
         $edit_icon.addClass('scb_ab_s_edit_white_img');
       } else {
         $(canvas).css('display', 'none');
         $(canvas).siblings('div').css('display', 'none');
         $(canvas).parent().siblings('.scb_ab_s_copy_button_container').css('display', 'none');
         $edit_icon.addClass('scb_ab_s_edit_grey_img');
+        $edit_icon.prop('disabled', true);
       }
     });
 
@@ -745,7 +746,7 @@ $(function() {
   }
 
   /* ADD HISTOGRAM button: Open Histogram Tools window */
-  $(".add_histogram_btn, .scb_ab_f_edit_histogram.scb_ab_s_edit_white_img").click(function () {
+  $(".add_histogram_btn, .scb_ab_f_edit_histogram.scb_ab_s_edit_white_img").click(function (event) {
     /* this btn has the id of the corresponding row */
     var row_id = $(this).data('row_id');
     /* Get name of the sample from the row itself */
@@ -767,6 +768,9 @@ $(function() {
       $(".scb_ab_s_select_histogram_view").show();
       paper.view.update();
     }
+    // Focus on close button
+    $('.scb_ab_s_dialog_title_close.scb_ab_f_close_dialog').focus();
+    event.preventDefault();
   });
 
   /* Open Image Dialog in Microscopy Analyze page */
@@ -887,6 +891,8 @@ $(function() {
         'cell_treatment': $(this).data('cell_treatment')
       });
     $(".scb_ab_s_copy_dialog").css('visibility', 'visible');
+    // Focus on close button
+    $('.scb_ab_s_dialog_title_close.scb_ab_f_close_copy_dialog').focus();
   });
 
   $('.scb_ab_f_close_copy_dialog').click(function(){

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -462,7 +462,6 @@ $(function() {
       $('.error_overlay').remove();
     };
     show_message(message, confirm_publish, cancel_publish);
-
   });
 
   /* Preview assignment*/
@@ -499,6 +498,15 @@ $(function() {
       $('.error_overlay').remove();
     };
     show_message(message, confirm_publish, cancel_publish);
+  });
+
+  /* jqDialog adds a keyup event handler to the document element that we do not want to be called
+     when the publish or delete links have focus and the ENTER key is used.
+     When this happens, the click event is triggered as well as the keyup event and its bubbling
+     cannot be cancelled with event.stopPropagation(). We remove all keyup event handlers on the
+     document instead. */
+  $(".scb_ab_f_publish, .scb_ab_f_delete_assignment").keydown(function(event) {
+    $(document).off();
   });
 
   function show_message(message, confirm_func, cancel_func) {

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -6,6 +6,33 @@ $(function() {
     $('.scb_s_dashboard_link', this).toggle();
   });
   /**
+   * Skip to sidebar and content links
+   */
+  var skip_to_sidebar = $('.scb_s_skip_to_sidebar'),
+      skip_to_content = $('.scb_s_skip_to_content'),
+      pathname = window.location.pathname,
+      is_entry_page = pathname === '/ab/assignments/',
+      is_select_technique_page = pathname === '/ab/assignments/select_technique/';
+  // No sidebar in entry page, hide the corresponding link
+  if (is_entry_page) {
+    skip_to_sidebar.hide();
+  }
+  skip_to_sidebar.click(function(e) {
+    if (is_select_technique_page) {
+      // Focus on first checkbox of Experimental Techniques
+      $('#tech_has_wb').focus();
+    } else {
+      // Focus on page related link
+      $('a[href="' + pathname + '"]').focus();
+    }
+    e.preventDefault();
+  });
+  skip_to_content.click(function(e) {
+    var content = is_entry_page ? $('.scb_s_dashboard_sidebar') : $('.scb_s_course_setup_description');
+    content.find(':focusable').first().focus();
+    e.preventDefault();
+  });
+  /**
    * Course setup
    */
   $('.scb_f_course_setup_create_new_course_option input').click(function() {

--- a/instructor/ui/instructor.js
+++ b/instructor/ui/instructor.js
@@ -1010,6 +1010,7 @@ $(function() {
       $imageForm = $('.scb_ab_s_image_form'),
       $fileInput = $imageForm.find('input[type="file"]'),
       $label = $imageForm.find('label[for="id_file"]'),
+      $anchor = $label.children('a'),
       $fileInput = $imageForm.find( 'input[type="file"]'),
       $filesSelect = $(".scb_ab_s_select_box"),
       droppedFiles = false,
@@ -1022,6 +1023,10 @@ $(function() {
                 .replace('{}', files.length) : files[0].name + " is ") + "uploading ...");
           }
       };
+  $anchor.on('click', function(e) {
+    e.preventDefault();
+    $label.click();
+  });
   // New event handler for the 'usual' file uploading (not drag&drop)
   $fileInput.on('change', function(e) {
       showFiles(e.target.files);


### PR DESCRIPTION
This PR enables focusability on all GUI elements that were formerly only clickable.

To attain this goal, all occurences of divs or spans that were used to mimic a clickable element were replaced by a corresponding button or anchor. Tabbing order was corrected to ensure a flow from top to bottom and left to right. All dialog windows now open up with focus on either their 'close' button or on the first focusable element of their body. That includes all the account management windows (Sign In, Reset Password, Create Instructor or Student Account etc.). Also, in these, the superfluous '*' character that was appended to the end of the labels was removed and error reporting now behaves correctly.

A black focus indicator was chosen and efforts were made to ensure it sticks closely to the shape of the GUI element ie it will be rounded for round buttons, rectangular for links and it will even follow the outline of some tabs were a triangle is attached below them.

In the instructor application,invisible links have been added to the right of the logo: 'Skip to sidebar' and 'Skip to content'. They will only appear if tab or shift+tab is pressed on the element preceding them (logo) or following them (contact). If enter is pressed, focus will be given to the corresponding item in the sidebar or in the content. The student application only contains a 'Skip to content' invisible link.

In every file that was going to be modified, an attempt was first made to start fixing their formatting which contained a mix or tabs and spaces, unnecessary blanks lines, erroneous indentation or missing blank line at the end of the file.

Functionality was barely touched and test always passed all along the way. A good way to test the changes is to try to create an assignment by using only the keyboard. And then visualize the result, student side, using the same method.

Here are the areas left though that are not fully keyboard accessible:

**Instructor side:**
- `Drag & Drop` in `Microscopy > Images`
- `Generating histograms` in` Flow Cytometry > Analyze`

**Student side:**
- The pages beyond `Western Blot Analyses`, `Flow Cytometry Analyses`, `Microscopy Analyses`. By inheriting some of the default CSS, most GUI elements, but not all, will display the focus indicator when tabbed to. The tabbing order might be incorrect though.

There are a lot of commits but most of them are small and can be squashed if you wish once the review is done and the PR accepted.