### PR TITLE
Added logic to remove query params from image url in student view

### DIFF
--- a/instructor/compiler.py
+++ b/instructor/compiler.py
@@ -1,3 +1,4 @@
+from urlparse import urlparse, urlunparse
 from django.db.models import Q
 from django.utils.html import format_html, format_html_join
 from instructor.models import (
@@ -362,7 +363,8 @@ def micro_model(a):
 def generate_slides(assignment):
     ret = {}
     for image in assignment.image.all():
-        ret[image.id] = image.file.url
+        image_url = urlparse(image.file.url)._replace(query=None)
+        ret[image.id] = urlunparse(image_url)
     return ret
 
 


### PR DESCRIPTION
#### What's this PR do?
The student assignment view was unable to load uploaded microscopy images because of an expiration parameter being appended to the S3 URL. This PR strips all query params from those URLs as they are not needed.

#### Where should the reviewer start?
`instructor/compiler.py`